### PR TITLE
Phase 4: Meeting Scheduler & Notifications

### DIFF
--- a/src/webparts/hbcProjectControls/components/App.tsx
+++ b/src/webparts/hbcProjectControls/components/App.tsx
@@ -15,6 +15,7 @@ import { LeadDetailPage } from './pages/hub/LeadDetailPage';
 import { LeadFormPage } from './pages/hub/LeadFormPage';
 import { GoNoGoScorecard } from './pages/hub/GoNoGoScorecard';
 import { GoNoGoDetail } from './pages/hub/GoNoGoDetail';
+import { GoNoGoMeetingScheduler } from './pages/hub/GoNoGoMeetingScheduler';
 
 // Precon pages
 import { EstimatingDashboard } from './pages/precon/EstimatingDashboard';
@@ -35,6 +36,7 @@ const HubRoutes: React.FC = () => (
     <Route path="/lead/:id" element={<LeadDetailPage />} />
     <Route path="/lead/:id/gonogo" element={<GoNoGoScorecard />} />
     <Route path="/lead/:id/gonogo/detail" element={<GoNoGoDetail />} />
+    <Route path="/lead/:id/schedule-gonogo" element={<GoNoGoMeetingScheduler />} />
   </Routes>
 );
 

--- a/src/webparts/hbcProjectControls/components/hooks/index.ts
+++ b/src/webparts/hbcProjectControls/components/hooks/index.ts
@@ -2,3 +2,5 @@ export { useLeads } from './useLeads';
 export { useGoNoGo } from './useGoNoGo';
 export { useEstimating } from './useEstimating';
 export { usePermission, useFeatureFlag } from './usePermission';
+export { useMeetings } from './useMeetings';
+export { useNotifications } from './useNotifications';

--- a/src/webparts/hbcProjectControls/components/hooks/useMeetings.ts
+++ b/src/webparts/hbcProjectControls/components/hooks/useMeetings.ts
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { useAppContext } from '../contexts/AppContext';
+import { IMeeting, ICalendarAvailability } from '../../models';
+
+interface IUseMeetingsResult {
+  meetings: IMeeting[];
+  availability: ICalendarAvailability[];
+  isLoading: boolean;
+  error: string | null;
+  fetchMeetings: (projectCode?: string) => Promise<void>;
+  fetchAvailability: (emails: string[], startDate: string, endDate: string) => Promise<void>;
+  createMeeting: (meeting: Partial<IMeeting>) => Promise<IMeeting>;
+}
+
+export function useMeetings(): IUseMeetingsResult {
+  const { dataService } = useAppContext();
+  const [meetings, setMeetings] = React.useState<IMeeting[]>([]);
+  const [availability, setAvailability] = React.useState<ICalendarAvailability[]>([]);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const fetchMeetings = React.useCallback(async (projectCode?: string) => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const items = await dataService.getMeetings(projectCode);
+      setMeetings(items);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch meetings');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [dataService]);
+
+  const fetchAvailability = React.useCallback(async (emails: string[], startDate: string, endDate: string) => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const items = await dataService.getCalendarAvailability(emails, startDate, endDate);
+      setAvailability(items);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch availability');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [dataService]);
+
+  const createMeeting = React.useCallback(async (meeting: Partial<IMeeting>): Promise<IMeeting> => {
+    const created = await dataService.createMeeting(meeting);
+    setMeetings(prev => [...prev, created]);
+    return created;
+  }, [dataService]);
+
+  return { meetings, availability, isLoading, error, fetchMeetings, fetchAvailability, createMeeting };
+}

--- a/src/webparts/hbcProjectControls/components/hooks/useNotifications.ts
+++ b/src/webparts/hbcProjectControls/components/hooks/useNotifications.ts
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { useAppContext } from '../contexts/AppContext';
+import { INotification, NotificationEvent } from '../../models';
+import { NotificationService, INotificationContext } from '../../services/NotificationService';
+
+interface IUseNotificationsResult {
+  notifications: INotification[];
+  isLoading: boolean;
+  error: string | null;
+  fetchNotifications: (projectCode?: string) => Promise<void>;
+  notify: (event: NotificationEvent, ctx: INotificationContext) => Promise<void>;
+}
+
+export function useNotifications(): IUseNotificationsResult {
+  const { dataService, currentUser } = useAppContext();
+  const [notifications, setNotifications] = React.useState<INotification[]>([]);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const notificationService = React.useMemo(
+    () => new NotificationService(dataService),
+    [dataService]
+  );
+
+  const fetchNotifications = React.useCallback(async (projectCode?: string) => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const items = await dataService.getNotifications(projectCode);
+      setNotifications(items);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch notifications');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [dataService]);
+
+  const notify = React.useCallback(async (event: NotificationEvent, ctx: INotificationContext) => {
+    const sentBy = currentUser?.email ?? 'system@hedrickbrothers.com';
+    const result = await notificationService.notify(event, ctx, sentBy);
+    if (result) {
+      setNotifications(prev => [result, ...prev]);
+    }
+  }, [notificationService, currentUser]);
+
+  return { notifications, isLoading, error, fetchNotifications, notify };
+}

--- a/src/webparts/hbcProjectControls/components/pages/hub/GoNoGoScorecard.tsx
+++ b/src/webparts/hbcProjectControls/components/pages/hub/GoNoGoScorecard.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { Button, Input, Select, Textarea } from '@fluentui/react-components';
 import { useGoNoGo } from '../../hooks/useGoNoGo';
 import { useLeads } from '../../hooks/useLeads';
+import { useNotifications } from '../../hooks/useNotifications';
 import { useAppContext } from '../../contexts/AppContext';
 import { PageHeader } from '../../shared/PageHeader';
 import { LoadingSpinner } from '../../shared/LoadingSpinner';
@@ -17,6 +18,7 @@ import {
   GoNoGoDecision,
   RoleName,
   Stage,
+  NotificationEvent,
 } from '../../../models';
 import { HBC_COLORS } from '../../../theme/tokens';
 import { PERMISSIONS } from '../../../utils/permissions';
@@ -62,6 +64,7 @@ export const GoNoGoScorecard: React.FC = () => {
   const { currentUser, hasPermission } = useAppContext();
   const { getScorecardByLeadId, createScorecard, updateScorecard, submitDecision } = useGoNoGo();
   const { getLeadById, updateLead } = useLeads();
+  const { notify } = useNotifications();
 
   const [lead, setLead] = React.useState<ILead | null>(null);
   const [scorecard, setScorecard] = React.useState<IScorecardModel | null>(null);
@@ -225,6 +228,16 @@ export const GoNoGoScorecard: React.FC = () => {
         console.log('[Mock] Reminder notification scheduled for WAIT decision');
         setToastMessage('WAIT decision recorded. Reminder notification scheduled.');
       }
+
+      // Fire-and-forget notification
+      notify(NotificationEvent.GoNoGoDecisionMade, {
+        leadTitle: lead?.Title,
+        leadId,
+        clientName: lead?.ClientName,
+        decision: dec,
+        score: cmteTotal || origTotal,
+        projectCode: dec === GoNoGoDecision.Go ? projectCode : undefined,
+      }).catch(console.error);
 
       setDecision(dec);
       setShowGoDialog(false);

--- a/src/webparts/hbcProjectControls/components/pages/hub/LeadDetailPage.tsx
+++ b/src/webparts/hbcProjectControls/components/pages/hub/LeadDetailPage.tsx
@@ -7,7 +7,7 @@ import { PageHeader } from '../../shared/PageHeader';
 import { StageBadge } from '../../shared/StageBadge';
 import { ScoreTierBadge } from '../../shared/ScoreTierBadge';
 import { LoadingSpinner } from '../../shared/LoadingSpinner';
-import { ILead } from '../../../models';
+import { ILead, Stage } from '../../../models';
 import { HBC_COLORS } from '../../../theme/tokens';
 import { formatCurrency, formatDate, formatSquareFeet } from '../../../utils/formatters';
 import { PERMISSIONS } from '../../../utils/permissions';
@@ -71,6 +71,11 @@ export const LeadDetailPage: React.FC = () => {
               lead.GoNoGoDecision
                 ? <Button appearance="subtle" onClick={() => navigate(`/lead/${lead.id}/gonogo/detail`)}>View Scorecard</Button>
                 : <Button appearance="primary" style={{ backgroundColor: '#F59E0B' }} onClick={() => navigate(`/lead/${lead.id}/gonogo`)}>Go/No-Go Scorecard</Button>
+            )}
+            {hasPermission(PERMISSIONS.MEETING_SCHEDULE) && lead.Stage === Stage.GoNoGoPending && (
+              <Button appearance="primary" onClick={() => navigate(`/lead/${lead.id}/schedule-gonogo`)}>
+                Schedule Go/No-Go
+              </Button>
             )}
             {hasPermission(PERMISSIONS.LEAD_EDIT) && !isEditing && (
               <Button appearance="primary" onClick={() => { setIsEditing(true); setEditData({}); }}>

--- a/src/webparts/hbcProjectControls/components/pages/hub/index.ts
+++ b/src/webparts/hbcProjectControls/components/pages/hub/index.ts
@@ -4,3 +4,4 @@ export { LeadDetailPage } from './LeadDetailPage';
 export { LeadFormPage } from './LeadFormPage';
 export { GoNoGoScorecard } from './GoNoGoScorecard';
 export { GoNoGoDetail } from './GoNoGoDetail';
+export { GoNoGoMeetingScheduler } from './GoNoGoMeetingScheduler';

--- a/src/webparts/hbcProjectControls/components/shared/MeetingScheduler.tsx
+++ b/src/webparts/hbcProjectControls/components/shared/MeetingScheduler.tsx
@@ -1,0 +1,362 @@
+import * as React from 'react';
+import { HBC_COLORS, SPACING } from '../../theme/tokens';
+import { IMeeting, ICalendarAvailability, ITimeSlot, MeetingType } from '../../models';
+import { useMeetings } from '../hooks/useMeetings';
+import { LoadingSpinner } from './LoadingSpinner';
+
+export interface IMeetingSchedulerProps {
+  meetingType: MeetingType;
+  subject: string;
+  attendeeEmails: string[];
+  leadId?: number;
+  projectCode?: string;
+  startDate: string;   // ISO date e.g. '2026-02-09'
+  endDate: string;     // ISO date e.g. '2026-02-13'
+  onScheduled: (meeting: IMeeting) => void;
+  onCancel?: () => void;
+}
+
+interface IDaySlots {
+  date: string;
+  label: string;
+  slots: { time: string; label: string; availableCount: number; total: number; available: boolean[] }[];
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
+}
+
+function buildGrid(
+  availability: ICalendarAvailability[],
+  attendeeEmails: string[]
+): IDaySlots[] {
+  if (availability.length === 0) return [];
+
+  // Collect all unique slot start times across all attendees
+  const slotMap = new Map<string, { time: string; available: boolean[] }>();
+
+  for (const person of availability) {
+    const emailIndex = attendeeEmails.indexOf(person.email);
+    if (emailIndex === -1) continue;
+
+    for (const slot of person.slots) {
+      const key = slot.start;
+      if (!slotMap.has(key)) {
+        slotMap.set(key, { time: slot.start, available: new Array(attendeeEmails.length).fill(false) as boolean[] });
+      }
+      const entry = slotMap.get(key)!;
+      entry.available[emailIndex] = slot.available;
+    }
+  }
+
+  // Group by day
+  const dayMap = new Map<string, IDaySlots>();
+  const sortedSlots = Array.from(slotMap.values()).sort(
+    (a, b) => new Date(a.time).getTime() - new Date(b.time).getTime()
+  );
+
+  for (const slot of sortedSlots) {
+    const dateStr = slot.time.split('T')[0];
+    if (!dayMap.has(dateStr)) {
+      dayMap.set(dateStr, {
+        date: dateStr,
+        label: formatDate(dateStr),
+        slots: [],
+      });
+    }
+    const availCount = slot.available.filter(Boolean).length;
+    dayMap.get(dateStr)!.slots.push({
+      time: slot.time,
+      label: formatTime(slot.time),
+      availableCount: availCount,
+      total: attendeeEmails.length,
+      available: slot.available,
+    });
+  }
+
+  return Array.from(dayMap.values());
+}
+
+function getSlotColor(availableCount: number, total: number): string {
+  if (total === 0) return HBC_COLORS.gray200;
+  const ratio = availableCount / total;
+  if (ratio === 1) return HBC_COLORS.success;
+  if (ratio >= 0.5) return HBC_COLORS.warningLight;
+  return HBC_COLORS.errorLight;
+}
+
+function getSlotBorder(availableCount: number, total: number): string {
+  if (total === 0) return HBC_COLORS.gray300;
+  const ratio = availableCount / total;
+  if (ratio === 1) return HBC_COLORS.success;
+  if (ratio >= 0.5) return HBC_COLORS.warning;
+  return HBC_COLORS.error;
+}
+
+export function MeetingScheduler({
+  meetingType,
+  subject,
+  attendeeEmails,
+  leadId,
+  projectCode,
+  startDate,
+  endDate,
+  onScheduled,
+  onCancel,
+}: IMeetingSchedulerProps): React.ReactElement {
+  const { availability, isLoading, error, fetchAvailability, createMeeting } = useMeetings();
+  const [selectedSlot, setSelectedSlot] = React.useState<string | null>(null);
+  const [scheduling, setScheduling] = React.useState(false);
+
+  React.useEffect(() => {
+    if (attendeeEmails.length > 0) {
+      fetchAvailability(attendeeEmails, startDate, endDate).catch(console.error);
+    }
+  }, [attendeeEmails, startDate, endDate, fetchAvailability]);
+
+  const grid = React.useMemo(
+    () => buildGrid(availability, attendeeEmails),
+    [availability, attendeeEmails]
+  );
+
+  const handleSchedule = React.useCallback(async () => {
+    if (!selectedSlot) return;
+
+    const slotStart = new Date(selectedSlot);
+    const slotEnd = new Date(slotStart.getTime() + 60 * 60 * 1000); // 1-hour meeting
+
+    setScheduling(true);
+    try {
+      const meeting = await createMeeting({
+        subject,
+        type: meetingType,
+        startTime: slotStart.toISOString(),
+        endTime: slotEnd.toISOString(),
+        attendees: attendeeEmails,
+        leadId,
+        projectCode,
+      });
+      onScheduled(meeting);
+    } catch {
+      // Error is captured in hook state
+    } finally {
+      setScheduling(false);
+    }
+  }, [selectedSlot, subject, meetingType, attendeeEmails, leadId, projectCode, createMeeting, onScheduled]);
+
+  // Styles
+  const containerStyle: React.CSSProperties = {
+    padding: SPACING.lg,
+    background: HBC_COLORS.white,
+    borderRadius: '8px',
+    border: `1px solid ${HBC_COLORS.gray200}`,
+  };
+
+  const headerStyle: React.CSSProperties = {
+    fontSize: '18px',
+    fontWeight: 600,
+    color: HBC_COLORS.navy,
+    marginBottom: SPACING.md,
+  };
+
+  const legendStyle: React.CSSProperties = {
+    display: 'flex',
+    gap: SPACING.md,
+    marginBottom: SPACING.md,
+    fontSize: '12px',
+    color: HBC_COLORS.gray600,
+  };
+
+  const legendItemStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '4px',
+  };
+
+  const legendSwatchStyle = (color: string): React.CSSProperties => ({
+    width: '12px',
+    height: '12px',
+    borderRadius: '2px',
+    background: color,
+  });
+
+  const gridContainerStyle: React.CSSProperties = {
+    display: 'flex',
+    gap: SPACING.md,
+    overflowX: 'auto',
+    marginBottom: SPACING.lg,
+  };
+
+  const dayColumnStyle: React.CSSProperties = {
+    minWidth: '140px',
+    flex: 1,
+  };
+
+  const dayHeaderStyle: React.CSSProperties = {
+    fontSize: '13px',
+    fontWeight: 600,
+    color: HBC_COLORS.navy,
+    padding: '6px 8px',
+    borderBottom: `2px solid ${HBC_COLORS.navy}`,
+    marginBottom: SPACING.sm,
+  };
+
+  const slotStyle = (bg: string, border: string, isSelected: boolean): React.CSSProperties => ({
+    padding: '8px 10px',
+    marginBottom: '4px',
+    borderRadius: '4px',
+    background: bg,
+    border: `2px solid ${isSelected ? HBC_COLORS.orange : border}`,
+    cursor: 'pointer',
+    fontSize: '12px',
+    transition: 'border-color 0.15s ease',
+    outline: isSelected ? `2px solid ${HBC_COLORS.orange}` : 'none',
+    outlineOffset: '1px',
+  });
+
+  const slotTimeStyle: React.CSSProperties = {
+    fontWeight: 600,
+    color: HBC_COLORS.gray800,
+  };
+
+  const slotCountStyle: React.CSSProperties = {
+    fontSize: '11px',
+    color: HBC_COLORS.gray500,
+    marginTop: '2px',
+  };
+
+  const attendeeListStyle: React.CSSProperties = {
+    marginBottom: SPACING.lg,
+    padding: SPACING.md,
+    background: HBC_COLORS.gray50,
+    borderRadius: '6px',
+    fontSize: '13px',
+    color: HBC_COLORS.gray700,
+  };
+
+  const buttonRowStyle: React.CSSProperties = {
+    display: 'flex',
+    gap: SPACING.sm,
+    justifyContent: 'flex-end',
+  };
+
+  const primaryBtnStyle: React.CSSProperties = {
+    padding: '8px 20px',
+    borderRadius: '6px',
+    border: 'none',
+    background: selectedSlot && !scheduling ? HBC_COLORS.orange : HBC_COLORS.gray300,
+    color: selectedSlot && !scheduling ? HBC_COLORS.white : HBC_COLORS.gray500,
+    fontWeight: 600,
+    fontSize: '14px',
+    cursor: selectedSlot && !scheduling ? 'pointer' : 'not-allowed',
+  };
+
+  const cancelBtnStyle: React.CSSProperties = {
+    padding: '8px 20px',
+    borderRadius: '6px',
+    border: `1px solid ${HBC_COLORS.gray300}`,
+    background: HBC_COLORS.white,
+    color: HBC_COLORS.gray700,
+    fontWeight: 500,
+    fontSize: '14px',
+    cursor: 'pointer',
+  };
+
+  if (isLoading && availability.length === 0) {
+    return <LoadingSpinner label="Loading availability..." />;
+  }
+
+  if (error) {
+    return (
+      <div style={{ ...containerStyle, color: HBC_COLORS.error }}>
+        Error loading availability: {error}
+      </div>
+    );
+  }
+
+  return (
+    <div style={containerStyle}>
+      <div style={headerStyle}>Schedule {subject}</div>
+
+      {/* Attendee list */}
+      <div style={attendeeListStyle}>
+        <strong>Attendees ({attendeeEmails.length}):</strong>{' '}
+        {availability.map(a => a.displayName).join(', ') || attendeeEmails.join(', ')}
+      </div>
+
+      {/* Legend */}
+      <div style={legendStyle}>
+        <div style={legendItemStyle}>
+          <span style={legendSwatchStyle(HBC_COLORS.success)} />
+          All available
+        </div>
+        <div style={legendItemStyle}>
+          <span style={legendSwatchStyle(HBC_COLORS.warningLight)} />
+          Partial
+        </div>
+        <div style={legendItemStyle}>
+          <span style={legendSwatchStyle(HBC_COLORS.errorLight)} />
+          Most unavailable
+        </div>
+      </div>
+
+      {/* Availability grid */}
+      {grid.length === 0 ? (
+        <div style={{ textAlign: 'center', padding: SPACING.xl, color: HBC_COLORS.gray500 }}>
+          No availability data found for the selected date range.
+        </div>
+      ) : (
+        <div style={gridContainerStyle}>
+          {grid.map(day => (
+            <div key={day.date} style={dayColumnStyle}>
+              <div style={dayHeaderStyle}>{day.label}</div>
+              {day.slots.map(slot => {
+                const bg = getSlotColor(slot.availableCount, slot.total);
+                const border = getSlotBorder(slot.availableCount, slot.total);
+                const isSelected = selectedSlot === slot.time;
+                return (
+                  <div
+                    key={slot.time}
+                    style={slotStyle(bg, border, isSelected)}
+                    onClick={() => setSelectedSlot(slot.time)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setSelectedSlot(slot.time); }}
+                  >
+                    <div style={slotTimeStyle}>{slot.label}</div>
+                    <div style={slotCountStyle}>
+                      {slot.availableCount}/{slot.total} available
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div style={buttonRowStyle}>
+        {onCancel && (
+          <button style={cancelBtnStyle} onClick={onCancel} type="button">
+            Cancel
+          </button>
+        )}
+        <button
+          style={primaryBtnStyle}
+          onClick={handleSchedule}
+          disabled={!selectedSlot || scheduling}
+          type="button"
+        >
+          {scheduling ? 'Scheduling...' : 'Schedule Meeting'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/webparts/hbcProjectControls/components/shared/index.ts
+++ b/src/webparts/hbcProjectControls/components/shared/index.ts
@@ -13,3 +13,5 @@ export type { IDataTableColumn } from './DataTable';
 export { PipelineChart } from './PipelineChart';
 export { ExportButtons } from './ExportButtons';
 export { StageIndicator } from './StageIndicator';
+export { MeetingScheduler } from './MeetingScheduler';
+export type { IMeetingSchedulerProps } from './MeetingScheduler';

--- a/src/webparts/hbcProjectControls/models/enums.ts
+++ b/src/webparts/hbcProjectControls/models/enums.ts
@@ -201,3 +201,16 @@ export enum NotificationType {
   Teams = 'Teams',
   Both = 'Both'
 }
+
+export enum NotificationEvent {
+  LeadSubmitted = 'LeadSubmitted',
+  GoNoGoScoringRequested = 'GoNoGoScoringRequested',
+  GoNoGoDecisionMade = 'GoNoGoDecisionMade',
+  SiteProvisioned = 'SiteProvisioned',
+  PreconKickoff = 'PreconKickoff',
+  DeliverableDueApproaching = 'DeliverableDueApproaching',
+  WinLossRecorded = 'WinLossRecorded',
+  AutopsyScheduled = 'AutopsyScheduled',
+  TurnoverCompleted = 'TurnoverCompleted',
+  SafetyFolderChanged = 'SafetyFolderChanged'
+}

--- a/src/webparts/hbcProjectControls/services/NotificationService.ts
+++ b/src/webparts/hbcProjectControls/services/NotificationService.ts
@@ -1,0 +1,184 @@
+import { IDataService } from './IDataService';
+import { INotification, NotificationType, NotificationEvent } from '../models';
+
+export interface INotificationContext {
+  leadTitle?: string;
+  leadId?: number;
+  projectCode?: string;
+  clientName?: string;
+  decision?: string;
+  score?: number;
+  meetingDate?: string;
+  dueDate?: string;
+  deliverableName?: string;
+  outcome?: string;
+  siteUrl?: string;
+  scheduledBy?: string;
+}
+
+interface INotificationTemplate {
+  subject: string;
+  body: string;
+  type: NotificationType;
+  recipientRoles: string[];
+}
+
+function buildTemplate(
+  event: NotificationEvent,
+  ctx: INotificationContext
+): INotificationTemplate {
+  switch (event) {
+    case NotificationEvent.LeadSubmitted:
+      return {
+        subject: `New Lead Submitted: ${ctx.leadTitle ?? 'Untitled'}`,
+        body: `A new lead "${ctx.leadTitle}" for client ${ctx.clientName ?? 'Unknown'} has been submitted and is awaiting Go/No-Go evaluation.`,
+        type: NotificationType.Both,
+        recipientRoles: ['Executive Leadership', 'Estimating Coordinator'],
+      };
+
+    case NotificationEvent.GoNoGoScoringRequested:
+      return {
+        subject: `Go/No-Go Scoring Requested: ${ctx.leadTitle ?? 'Untitled'}`,
+        body: `A Go/No-Go scorecard has been created for "${ctx.leadTitle}" (${ctx.clientName ?? ''}). Committee members are requested to complete their scoring.`,
+        type: NotificationType.Both,
+        recipientRoles: ['Executive Leadership'],
+      };
+
+    case NotificationEvent.GoNoGoDecisionMade:
+      return {
+        subject: `Go/No-Go Decision: ${ctx.decision ?? 'Pending'} — ${ctx.leadTitle ?? 'Untitled'}`,
+        body: `The Go/No-Go committee has made a "${ctx.decision}" decision for "${ctx.leadTitle}" (${ctx.clientName ?? ''}).${ctx.score !== undefined ? ` Final score: ${ctx.score}/92.` : ''}${ctx.projectCode ? ` Project code: ${ctx.projectCode}.` : ''}`,
+        type: NotificationType.Both,
+        recipientRoles: ['BD Representative', 'Executive Leadership', 'Estimating Coordinator', 'Preconstruction Team'],
+      };
+
+    case NotificationEvent.SiteProvisioned:
+      return {
+        subject: `Project Site Provisioned: ${ctx.projectCode ?? ''}`,
+        body: `A SharePoint project site has been provisioned for "${ctx.leadTitle}" (${ctx.projectCode ?? ''}).${ctx.siteUrl ? ` Site URL: ${ctx.siteUrl}` : ''}`,
+        type: NotificationType.Both,
+        recipientRoles: ['BD Representative', 'Executive Leadership', 'Operations Team', 'Preconstruction Team'],
+      };
+
+    case NotificationEvent.PreconKickoff:
+      return {
+        subject: `Precon Kickoff Scheduled: ${ctx.leadTitle ?? 'Untitled'}`,
+        body: `A preconstruction kickoff meeting has been scheduled for "${ctx.leadTitle}" (${ctx.projectCode ?? ''}).${ctx.meetingDate ? ` Date: ${ctx.meetingDate}.` : ''}`,
+        type: NotificationType.Both,
+        recipientRoles: ['BD Representative', 'Estimating Coordinator', 'Preconstruction Team', 'Executive Leadership'],
+      };
+
+    case NotificationEvent.DeliverableDueApproaching:
+      return {
+        subject: `Deliverable Due Soon: ${ctx.deliverableName ?? 'Untitled'}`,
+        body: `The deliverable "${ctx.deliverableName}" for project ${ctx.projectCode ?? ''} is due on ${ctx.dueDate ?? 'TBD'}.`,
+        type: NotificationType.Email,
+        recipientRoles: ['Estimating Coordinator', 'Preconstruction Team'],
+      };
+
+    case NotificationEvent.WinLossRecorded:
+      return {
+        subject: `${ctx.outcome ?? 'Win/Loss'} Recorded: ${ctx.leadTitle ?? 'Untitled'}`,
+        body: `A "${ctx.outcome}" outcome has been recorded for "${ctx.leadTitle}" (${ctx.clientName ?? ''}).`,
+        type: NotificationType.Both,
+        recipientRoles: ['BD Representative', 'Executive Leadership', 'Marketing'],
+      };
+
+    case NotificationEvent.AutopsyScheduled:
+      return {
+        subject: `Loss Autopsy Scheduled: ${ctx.leadTitle ?? 'Untitled'}`,
+        body: `A loss autopsy meeting has been scheduled for "${ctx.leadTitle}" (${ctx.clientName ?? ''}).${ctx.meetingDate ? ` Date: ${ctx.meetingDate}.` : ''}${ctx.scheduledBy ? ` Scheduled by: ${ctx.scheduledBy}.` : ''}`,
+        type: NotificationType.Both,
+        recipientRoles: ['BD Representative', 'Executive Leadership', 'Estimating Coordinator'],
+      };
+
+    case NotificationEvent.TurnoverCompleted:
+      return {
+        subject: `Turnover Completed: ${ctx.projectCode ?? ''}`,
+        body: `Project turnover has been completed for ${ctx.projectCode ?? 'Unknown project'} ("${ctx.leadTitle ?? ''}").`,
+        type: NotificationType.Both,
+        recipientRoles: ['BD Representative', 'Executive Leadership', 'Operations Team'],
+      };
+
+    case NotificationEvent.SafetyFolderChanged:
+      return {
+        subject: `Safety Folder Updated: ${ctx.projectCode ?? ''}`,
+        body: `The safety folder for project ${ctx.projectCode ?? ''} has been updated.`,
+        type: NotificationType.Email,
+        recipientRoles: ['Safety', 'Operations Team'],
+      };
+  }
+}
+
+export class NotificationService {
+  private dataService: IDataService;
+  private usersByRole: Map<string, string[]> | undefined;
+
+  constructor(dataService: IDataService) {
+    this.dataService = dataService;
+  }
+
+  /**
+   * Lazily load user-role mapping from the data service.
+   */
+  private async getUsersByRole(): Promise<Map<string, string[]>> {
+    if (this.usersByRole) {
+      return this.usersByRole;
+    }
+
+    const roles = await this.dataService.getRoles();
+    const map = new Map<string, string[]>();
+    for (const role of roles) {
+      map.set(role.Title, role.UserOrGroup ?? []);
+    }
+    this.usersByRole = map;
+    return map;
+  }
+
+  /**
+   * Resolve email recipients from a list of role names.
+   */
+  private async resolveRecipients(roleNames: string[]): Promise<string[]> {
+    const roleMap = await this.getUsersByRole();
+    const emailSet = new Set<string>();
+
+    for (const roleName of roleNames) {
+      const emails = roleMap.get(roleName) ?? [];
+      for (const email of emails) {
+        emailSet.add(email);
+      }
+    }
+
+    return Array.from(emailSet);
+  }
+
+  /**
+   * Send a notification for a given event. Fire-and-forget safe — returns
+   * the created notification or undefined if it fails silently.
+   */
+  public async notify(
+    event: NotificationEvent,
+    ctx: INotificationContext,
+    sentBy: string
+  ): Promise<INotification | undefined> {
+    const template = buildTemplate(event, ctx);
+    const recipients = await this.resolveRecipients(template.recipientRoles);
+
+    if (recipients.length === 0) {
+      return undefined;
+    }
+
+    const notification = await this.dataService.sendNotification({
+      type: template.type,
+      subject: template.subject,
+      body: template.body,
+      recipients,
+      sentBy,
+      relatedEntityType: ctx.leadId !== undefined ? 'Lead' : ctx.projectCode ? 'Project' : undefined,
+      relatedEntityId: ctx.leadId !== undefined ? String(ctx.leadId) : ctx.projectCode,
+      projectCode: ctx.projectCode,
+    });
+
+    return notification;
+  }
+}

--- a/src/webparts/hbcProjectControls/services/index.ts
+++ b/src/webparts/hbcProjectControls/services/index.ts
@@ -10,3 +10,5 @@ export type { IGraphService } from './GraphService';
 export { OfflineQueueService } from './OfflineQueueService';
 export { PowerAutomateService } from './PowerAutomateService';
 export type { IProvisioningPayload } from './PowerAutomateService';
+export { NotificationService } from './NotificationService';
+export type { INotificationContext } from './NotificationService';


### PR DESCRIPTION
## Summary
- **NotificationService** with templates for 10 event types (LeadSubmitted, GoNoGoScoringRequested, GoNoGoDecisionMade, SiteProvisioned, PreconKickoff, DeliverableDueApproaching, WinLossRecorded, AutopsyScheduled, TurnoverCompleted, SafetyFolderChanged). Resolves recipients by role, supports Email/Teams/Both channels.
- **MeetingScheduler** reusable shared component with calendar availability grid. Displays day columns with color-coded time slots (green=all available, amber=partial, red=most unavailable). Click-to-select and schedule.
- **GoNoGoMeetingScheduler** page at `/lead/:id/schedule-gonogo` wrapping MeetingScheduler for GNG committee meetings. RBAC-gated to BD Representative and Executive Leadership.
- **useMeetings** and **useNotifications** hooks following existing hook patterns.
- Fire-and-forget notification integrations wired into **LeadFormPage** (LeadSubmitted on create) and **GoNoGoScorecard** (GoNoGoDecisionMade on decision).
- "Schedule Go/No-Go" button added to **LeadDetailPage** for GoNoGo-Pending stage leads (permission-gated).

## New Files
- `services/NotificationService.ts`
- `components/hooks/useMeetings.ts`
- `components/hooks/useNotifications.ts`
- `components/shared/MeetingScheduler.tsx`
- `components/pages/hub/GoNoGoMeetingScheduler.tsx`

## Modified Files
- `models/enums.ts` — Added `NotificationEvent` enum
- `services/index.ts`, `hooks/index.ts`, `shared/index.ts`, `hub/index.ts` — Barrel exports
- `App.tsx` — Added route
- `LeadFormPage.tsx`, `GoNoGoScorecard.tsx`, `LeadDetailPage.tsx` — Integration points

## Test plan
- [ ] Verify `tsc --noEmit` passes with 0 errors
- [ ] Verify `gulp build` succeeds
- [ ] Navigate to a GoNoGo-Pending lead detail page and confirm "Schedule Go/No-Go" button appears
- [ ] Click "Schedule Go/No-Go" and verify availability grid renders with attendee data
- [ ] Select a time slot and schedule a meeting; confirm navigation back to lead detail
- [ ] Create a new lead and confirm no console errors from notification dispatch
- [ ] Submit a Go/No-Go decision and confirm notification fires without blocking the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)