### PR TITLE
Phase 5: Site Provisioning Engine

### DIFF
--- a/src/webparts/hbcProjectControls/components/App.tsx
+++ b/src/webparts/hbcProjectControls/components/App.tsx
@@ -16,6 +16,7 @@ import { LeadFormPage } from './pages/hub/LeadFormPage';
 import { GoNoGoScorecard } from './pages/hub/GoNoGoScorecard';
 import { GoNoGoDetail } from './pages/hub/GoNoGoDetail';
 import { GoNoGoMeetingScheduler } from './pages/hub/GoNoGoMeetingScheduler';
+import { AdminPanel } from './pages/hub/AdminPanel';
 
 // Precon pages
 import { EstimatingDashboard } from './pages/precon/EstimatingDashboard';
@@ -37,6 +38,7 @@ const HubRoutes: React.FC = () => (
     <Route path="/lead/:id/gonogo" element={<GoNoGoScorecard />} />
     <Route path="/lead/:id/gonogo/detail" element={<GoNoGoDetail />} />
     <Route path="/lead/:id/schedule-gonogo" element={<GoNoGoMeetingScheduler />} />
+    <Route path="/admin" element={<AdminPanel />} />
   </Routes>
 );
 

--- a/src/webparts/hbcProjectControls/components/pages/hub/AdminPanel.tsx
+++ b/src/webparts/hbcProjectControls/components/pages/hub/AdminPanel.tsx
@@ -1,0 +1,263 @@
+import * as React from 'react';
+import { Button } from '@fluentui/react-components';
+import { useAppContext } from '../../contexts/AppContext';
+import { PageHeader } from '../../shared/PageHeader';
+import { DataTable, IDataTableColumn } from '../../shared/DataTable';
+import { LoadingSpinner } from '../../shared/LoadingSpinner';
+import { ProvisioningStatusView } from '../../shared/ProvisioningStatus';
+import { RoleGate } from '../../guards/RoleGate';
+import { IProvisioningLog, ProvisioningStatus, RoleName } from '../../../models';
+import { ProvisioningService } from '../../../services/ProvisioningService';
+import { HBC_COLORS, SPACING } from '../../../theme/tokens';
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString('en-US', {
+    month: 'short', day: 'numeric', year: 'numeric',
+    hour: 'numeric', minute: '2-digit',
+  });
+}
+
+function getStatusBadgeColor(status: ProvisioningStatus): string {
+  switch (status) {
+    case ProvisioningStatus.Completed: return HBC_COLORS.success;
+    case ProvisioningStatus.InProgress: return HBC_COLORS.info;
+    case ProvisioningStatus.Queued: return HBC_COLORS.gray400;
+    case ProvisioningStatus.PartialFailure:
+    case ProvisioningStatus.Failed: return HBC_COLORS.error;
+    default: return HBC_COLORS.gray400;
+  }
+}
+
+export const AdminPanel: React.FC = () => {
+  const { dataService } = useAppContext();
+  const [logs, setLogs] = React.useState<IProvisioningLog[]>([]);
+  const [isLoading, setIsLoading] = React.useState(true);
+  const [retrying, setRetrying] = React.useState<string | null>(null);
+  const [expandedCode, setExpandedCode] = React.useState<string | null>(null);
+
+  const provisioningService = React.useMemo(
+    () => new ProvisioningService(dataService),
+    [dataService]
+  );
+
+  const fetchLogs = React.useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const items = await dataService.getProvisioningLogs();
+      setLogs(items);
+    } catch (err) {
+      console.error('Failed to fetch provisioning logs:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [dataService]);
+
+  React.useEffect(() => {
+    fetchLogs().catch(console.error);
+  }, [fetchLogs]);
+
+  // Poll for updates while any log is in-progress
+  React.useEffect(() => {
+    const hasActive = logs.some(
+      l => l.status === ProvisioningStatus.InProgress || l.status === ProvisioningStatus.Queued
+    );
+    if (!hasActive) return;
+
+    const interval = setInterval(() => {
+      fetchLogs().catch(console.error);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [logs, fetchLogs]);
+
+  const handleRetry = React.useCallback(async (log: IProvisioningLog) => {
+    const fromStep = log.failedStep ?? log.completedSteps + 1;
+    setRetrying(log.projectCode);
+    try {
+      await provisioningService.retryFromStep(log.projectCode, fromStep);
+      await fetchLogs();
+    } catch (err) {
+      console.error('Retry failed:', err);
+    } finally {
+      setRetrying(null);
+    }
+  }, [provisioningService, fetchLogs]);
+
+  const columns: IDataTableColumn<IProvisioningLog>[] = [
+    {
+      key: 'projectCode',
+      header: 'Project Code',
+      width: '120px',
+      render: (item) => (
+        <span style={{ fontFamily: 'monospace', fontWeight: 600, color: HBC_COLORS.navy }}>
+          {item.projectCode}
+        </span>
+      ),
+    },
+    {
+      key: 'projectName',
+      header: 'Project Name',
+      width: '200px',
+      render: (item) => <span>{item.projectName}</span>,
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      width: '130px',
+      render: (item) => (
+        <span style={{
+          display: 'inline-block',
+          padding: '2px 8px',
+          borderRadius: '10px',
+          fontSize: '11px',
+          fontWeight: 600,
+          color: HBC_COLORS.white,
+          backgroundColor: getStatusBadgeColor(item.status),
+        }}>
+          {item.status}
+        </span>
+      ),
+    },
+    {
+      key: 'progress',
+      header: 'Progress',
+      width: '100px',
+      render: (item) => <span>{item.completedSteps}/7 steps</span>,
+    },
+    {
+      key: 'error',
+      header: 'Error',
+      width: '200px',
+      render: (item) => (
+        <span style={{ fontSize: '12px', color: item.errorMessage ? HBC_COLORS.error : HBC_COLORS.gray400 }}>
+          {item.errorMessage || '-'}
+        </span>
+      ),
+    },
+    {
+      key: 'retryCount',
+      header: 'Retries',
+      width: '70px',
+      render: (item) => <span>{item.retryCount}</span>,
+    },
+    {
+      key: 'requestedBy',
+      header: 'Requested By',
+      width: '160px',
+      render: (item) => <span>{item.requestedBy}</span>,
+    },
+    {
+      key: 'requestedAt',
+      header: 'Requested At',
+      width: '160px',
+      render: (item) => <span>{formatDateTime(item.requestedAt)}</span>,
+    },
+    {
+      key: 'actions',
+      header: 'Actions',
+      width: '120px',
+      render: (item) => {
+        const canRetry = item.status === ProvisioningStatus.Failed ||
+          item.status === ProvisioningStatus.PartialFailure;
+        const canExpand = true;
+
+        return (
+          <div style={{ display: 'flex', gap: '4px' }}>
+            {canRetry && (
+              <Button
+                appearance="primary"
+                size="small"
+                style={{ backgroundColor: HBC_COLORS.orange, fontSize: '11px' }}
+                disabled={retrying === item.projectCode}
+                onClick={(e) => { e.stopPropagation(); handleRetry(item).catch(console.error); }}
+              >
+                {retrying === item.projectCode ? 'Retrying...' : 'Retry'}
+              </Button>
+            )}
+            {canExpand && (
+              <Button
+                appearance="subtle"
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setExpandedCode(expandedCode === item.projectCode ? null : item.projectCode);
+                }}
+              >
+                {expandedCode === item.projectCode ? 'Hide' : 'Details'}
+              </Button>
+            )}
+          </div>
+        );
+      },
+    },
+  ];
+
+  return (
+    <RoleGate
+      allowedRoles={[RoleName.ExecutiveLeadership, RoleName.IDS]}
+      fallback={
+        <div style={{ padding: '48px', textAlign: 'center', color: HBC_COLORS.gray500 }}>
+          <h3>Access Restricted</h3>
+          <p>Admin panel is restricted to Executive Leadership and IDS roles.</p>
+        </div>
+      }
+    >
+      <PageHeader
+        title="Admin Panel"
+        subtitle="Site Provisioning Management"
+        actions={
+          <Button appearance="secondary" onClick={() => fetchLogs().catch(console.error)}>
+            Refresh
+          </Button>
+        }
+      />
+
+      {isLoading && logs.length === 0 ? (
+        <LoadingSpinner label="Loading provisioning logs..." />
+      ) : (
+        <>
+          <DataTable
+            columns={columns}
+            items={logs}
+            keyExtractor={(item) => item.id}
+            emptyTitle="No Provisioning Requests"
+            emptyDescription="Provisioning logs will appear here when GO decisions trigger site creation."
+          />
+
+          {/* Expanded detail view */}
+          {expandedCode && (
+            <div style={{
+              marginTop: SPACING.md,
+              padding: SPACING.lg,
+              background: HBC_COLORS.gray50,
+              borderRadius: '8px',
+              border: `1px solid ${HBC_COLORS.gray200}`,
+            }}>
+              <div style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                marginBottom: SPACING.md,
+              }}>
+                <span style={{ fontSize: '14px', fontWeight: 600, color: HBC_COLORS.navy }}>
+                  Provisioning Details: {expandedCode}
+                </span>
+                <Button
+                  appearance="subtle"
+                  size="small"
+                  onClick={() => setExpandedCode(null)}
+                >
+                  Close
+                </Button>
+              </div>
+              <ProvisioningStatusView
+                projectCode={expandedCode}
+                pollInterval={1000}
+              />
+            </div>
+          )}
+        </>
+      )}
+    </RoleGate>
+  );
+};

--- a/src/webparts/hbcProjectControls/components/pages/hub/LeadDetailPage.tsx
+++ b/src/webparts/hbcProjectControls/components/pages/hub/LeadDetailPage.tsx
@@ -7,7 +7,8 @@ import { PageHeader } from '../../shared/PageHeader';
 import { StageBadge } from '../../shared/StageBadge';
 import { ScoreTierBadge } from '../../shared/ScoreTierBadge';
 import { LoadingSpinner } from '../../shared/LoadingSpinner';
-import { ILead, Stage } from '../../../models';
+import { ILead, Stage, GoNoGoDecision } from '../../../models';
+import { ProvisioningStatusView } from '../../shared/ProvisioningStatus';
 import { HBC_COLORS } from '../../../theme/tokens';
 import { formatCurrency, formatDate, formatSquareFeet } from '../../../utils/formatters';
 import { PERMISSIONS } from '../../../utils/permissions';
@@ -210,6 +211,32 @@ export const LeadDetailPage: React.FC = () => {
                     {lead.GoNoGoDecision}
                   </span>
                 </div>
+              )}
+            </div>
+          )}
+
+          {/* Provisioning Status — shown after GO decision */}
+          {lead.GoNoGoDecision === GoNoGoDecision.Go && lead.ProjectCode && (
+            <div style={{ marginTop: '16px' }}>
+              {lead.ProjectSiteURL ? (
+                <div style={{
+                  backgroundColor: '#fff',
+                  borderRadius: '8px',
+                  padding: '24px',
+                  boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+                }}>
+                  <h3 style={{ margin: '0 0 12px', color: HBC_COLORS.navy }}>Project Site</h3>
+                  <a
+                    href={lead.ProjectSiteURL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ color: HBC_COLORS.navy, fontWeight: 600, fontSize: '14px' }}
+                  >
+                    {lead.ProjectSiteURL}
+                  </a>
+                </div>
+              ) : (
+                <ProvisioningStatusView projectCode={lead.ProjectCode} compact pollInterval={1000} />
               )}
             </div>
           )}

--- a/src/webparts/hbcProjectControls/components/pages/hub/index.ts
+++ b/src/webparts/hbcProjectControls/components/pages/hub/index.ts
@@ -5,3 +5,4 @@ export { LeadFormPage } from './LeadFormPage';
 export { GoNoGoScorecard } from './GoNoGoScorecard';
 export { GoNoGoDetail } from './GoNoGoDetail';
 export { GoNoGoMeetingScheduler } from './GoNoGoMeetingScheduler';
+export { AdminPanel } from './AdminPanel';

--- a/src/webparts/hbcProjectControls/components/shared/ProvisioningStatus.tsx
+++ b/src/webparts/hbcProjectControls/components/shared/ProvisioningStatus.tsx
@@ -1,0 +1,245 @@
+import * as React from 'react';
+import { HBC_COLORS, SPACING } from '../../theme/tokens';
+import { IProvisioningLog, ProvisioningStatus as ProvStatus, PROVISIONING_STEPS, TOTAL_PROVISIONING_STEPS } from '../../models';
+import { useAppContext } from '../contexts/AppContext';
+import { LoadingSpinner } from './LoadingSpinner';
+
+export interface IProvisioningStatusProps {
+  projectCode: string;
+  /** If provided, skip polling and use this log directly */
+  log?: IProvisioningLog;
+  /** Poll interval in ms. Default 800ms. Set to 0 to disable polling. */
+  pollInterval?: number;
+  /** Compact mode for inline display */
+  compact?: boolean;
+}
+
+function getStatusColor(status: ProvStatus): string {
+  switch (status) {
+    case ProvStatus.Completed: return HBC_COLORS.success;
+    case ProvStatus.InProgress: return HBC_COLORS.info;
+    case ProvStatus.Queued: return HBC_COLORS.gray400;
+    case ProvStatus.PartialFailure:
+    case ProvStatus.Failed: return HBC_COLORS.error;
+    default: return HBC_COLORS.gray400;
+  }
+}
+
+function getStatusLabel(status: ProvStatus): string {
+  switch (status) {
+    case ProvStatus.Completed: return 'Completed';
+    case ProvStatus.InProgress: return 'In Progress';
+    case ProvStatus.Queued: return 'Queued';
+    case ProvStatus.PartialFailure: return 'Partial Failure';
+    case ProvStatus.Failed: return 'Failed';
+    default: return 'Unknown';
+  }
+}
+
+export function ProvisioningStatusView({
+  projectCode,
+  log: externalLog,
+  pollInterval = 800,
+  compact = false,
+}: IProvisioningStatusProps): React.ReactElement {
+  const { dataService } = useAppContext();
+  const [log, setLog] = React.useState<IProvisioningLog | null>(externalLog ?? null);
+  const [loading, setLoading] = React.useState(!externalLog);
+
+  React.useEffect(() => {
+    if (externalLog) {
+      setLog(externalLog);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchStatus = async (): Promise<void> => {
+      const result = await dataService.getProvisioningStatus(projectCode);
+      if (!cancelled) {
+        setLog(result);
+        setLoading(false);
+      }
+    };
+
+    fetchStatus().catch(console.error);
+
+    if (pollInterval > 0) {
+      const interval = setInterval(() => {
+        fetchStatus().catch(console.error);
+      }, pollInterval);
+
+      return () => { cancelled = true; clearInterval(interval); };
+    }
+
+    return () => { cancelled = true; };
+  }, [projectCode, externalLog, pollInterval, dataService]);
+
+  // Stop polling once completed or failed
+  const isTerminal = log?.status === ProvStatus.Completed ||
+    log?.status === ProvStatus.Failed ||
+    log?.status === ProvStatus.PartialFailure;
+
+  React.useEffect(() => {
+    if (isTerminal || !log || externalLog || pollInterval <= 0) return;
+
+    let cancelled = false;
+    const interval = setInterval(async () => {
+      if (cancelled) return;
+      const result = await dataService.getProvisioningStatus(projectCode);
+      if (!cancelled) setLog(result);
+    }, pollInterval);
+
+    return () => { cancelled = true; clearInterval(interval); };
+  }, [isTerminal, log, externalLog, pollInterval, projectCode, dataService]);
+
+  if (loading && !log) {
+    return <LoadingSpinner label="Loading provisioning status..." />;
+  }
+
+  if (!log) {
+    return (
+      <div style={{ fontSize: '13px', color: HBC_COLORS.gray500 }}>
+        No provisioning record found.
+      </div>
+    );
+  }
+
+  const containerStyle: React.CSSProperties = {
+    padding: compact ? SPACING.md : SPACING.lg,
+    background: HBC_COLORS.white,
+    borderRadius: '8px',
+    border: `1px solid ${HBC_COLORS.gray200}`,
+  };
+
+  const badgeStyle: React.CSSProperties = {
+    display: 'inline-block',
+    padding: '4px 12px',
+    borderRadius: '12px',
+    fontSize: '12px',
+    fontWeight: 600,
+    color: HBC_COLORS.white,
+    backgroundColor: getStatusColor(log.status),
+    marginBottom: compact ? SPACING.sm : SPACING.md,
+  };
+
+  return (
+    <div style={containerStyle}>
+      {!compact && (
+        <div style={{ fontSize: '16px', fontWeight: 600, color: HBC_COLORS.navy, marginBottom: SPACING.sm }}>
+          Site Provisioning
+        </div>
+      )}
+
+      <div style={badgeStyle}>{getStatusLabel(log.status)}</div>
+
+      {/* Vertical stepper */}
+      <div style={{ marginTop: SPACING.sm }}>
+        {PROVISIONING_STEPS.map(({ step, label }) => {
+          const isCompleted = log.completedSteps >= step;
+          const isCurrent = log.status === ProvStatus.InProgress && log.currentStep === step && !isCompleted;
+          const isFailed = log.failedStep === step;
+
+          let dotColor: string = HBC_COLORS.gray300;
+          let textColor: string = HBC_COLORS.gray400;
+          let lineColor: string = HBC_COLORS.gray200;
+
+          if (isCompleted) {
+            dotColor = HBC_COLORS.success;
+            textColor = HBC_COLORS.gray700;
+            lineColor = HBC_COLORS.success;
+          } else if (isCurrent) {
+            dotColor = HBC_COLORS.info;
+            textColor = HBC_COLORS.navy;
+          } else if (isFailed) {
+            dotColor = HBC_COLORS.error;
+            textColor = HBC_COLORS.error;
+          }
+
+          const dotSize = compact ? 16 : 20;
+          const fontSize = compact ? '12px' : '13px';
+
+          return (
+            <div key={step} style={{ display: 'flex', alignItems: 'flex-start', position: 'relative' }}>
+              {/* Connector line */}
+              {step < TOTAL_PROVISIONING_STEPS && (
+                <div style={{
+                  position: 'absolute',
+                  left: `${dotSize / 2 - 1}px`,
+                  top: `${dotSize}px`,
+                  width: '2px',
+                  height: compact ? '20px' : '24px',
+                  backgroundColor: isCompleted ? lineColor : HBC_COLORS.gray200,
+                }} />
+              )}
+
+              {/* Dot */}
+              <div style={{
+                width: `${dotSize}px`,
+                height: `${dotSize}px`,
+                borderRadius: '50%',
+                backgroundColor: dotColor,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+                marginRight: SPACING.sm,
+              }}>
+                {isCompleted && (
+                  <span style={{ color: HBC_COLORS.white, fontSize: '10px', fontWeight: 700 }}>&#10003;</span>
+                )}
+                {isCurrent && (
+                  <span style={{ color: HBC_COLORS.white, fontSize: '9px', fontWeight: 700 }}>&#9679;</span>
+                )}
+                {isFailed && (
+                  <span style={{ color: HBC_COLORS.white, fontSize: '10px', fontWeight: 700 }}>&#10007;</span>
+                )}
+              </div>
+
+              {/* Label */}
+              <div style={{
+                paddingBottom: compact ? '12px' : '16px',
+                fontSize,
+                color: textColor,
+                fontWeight: isCurrent ? 600 : 400,
+                lineHeight: `${dotSize}px`,
+              }}>
+                <span>Step {step}: {label}</span>
+                {isFailed && log.errorMessage && (
+                  <div style={{
+                    fontSize: '11px',
+                    color: HBC_COLORS.error,
+                    marginTop: '2px',
+                  }}>
+                    {log.errorMessage}
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Site URL link on completion */}
+      {log.status === ProvStatus.Completed && log.siteUrl && (
+        <div style={{
+          marginTop: SPACING.sm,
+          padding: SPACING.sm,
+          backgroundColor: HBC_COLORS.successLight,
+          borderRadius: '6px',
+          fontSize: '13px',
+        }}>
+          <strong>Project site ready: </strong>
+          <a
+            href={log.siteUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: HBC_COLORS.navy, fontWeight: 600 }}
+          >
+            {log.siteUrl}
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/webparts/hbcProjectControls/components/shared/index.ts
+++ b/src/webparts/hbcProjectControls/components/shared/index.ts
@@ -15,3 +15,5 @@ export { ExportButtons } from './ExportButtons';
 export { StageIndicator } from './StageIndicator';
 export { MeetingScheduler } from './MeetingScheduler';
 export type { IMeetingSchedulerProps } from './MeetingScheduler';
+export { ProvisioningStatusView } from './ProvisioningStatus';
+export type { IProvisioningStatusProps } from './ProvisioningStatus';

--- a/src/webparts/hbcProjectControls/models/IProvisioningLog.ts
+++ b/src/webparts/hbcProjectControls/models/IProvisioningLog.ts
@@ -1,0 +1,30 @@
+import { ProvisioningStatus } from './enums';
+
+export const PROVISIONING_STEPS = [
+  { step: 1, label: 'Create SharePoint Site' },
+  { step: 2, label: 'Apply PnP Template' },
+  { step: 3, label: 'Hub Association' },
+  { step: 4, label: 'Security Groups & Members' },
+  { step: 5, label: 'Copy Templates from Registry' },
+  { step: 6, label: 'Copy Lead Data & Documents' },
+  { step: 7, label: 'Update Leads_Master with Site URL' },
+] as const;
+
+export const TOTAL_PROVISIONING_STEPS = 7;
+
+export interface IProvisioningLog {
+  id: number;
+  projectCode: string;
+  projectName: string;
+  leadId: number;
+  status: ProvisioningStatus;
+  currentStep: number;
+  completedSteps: number;
+  failedStep?: number;
+  errorMessage?: string;
+  retryCount: number;
+  siteUrl?: string;
+  requestedBy: string;
+  requestedAt: string;
+  completedAt?: string;
+}

--- a/src/webparts/hbcProjectControls/models/index.ts
+++ b/src/webparts/hbcProjectControls/models/index.ts
@@ -7,3 +7,4 @@ export * from './IFeatureFlag';
 export * from './IMeeting';
 export * from './INotification';
 export * from './IAuditEntry';
+export * from './IProvisioningLog';

--- a/src/webparts/hbcProjectControls/provisioning/site-template.json
+++ b/src/webparts/hbcProjectControls/provisioning/site-template.json
@@ -1,0 +1,361 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/pnp/provisioning-schema-2022-09",
+  "description": "HBC Project Controls — Project Site Provisioning Template",
+  "version": "1.0.0",
+  "template": {
+    "siteSettings": {
+      "template": "STS#3",
+      "title": "{{ProjectCode}} — {{ProjectName}}",
+      "description": "Hedrick Brothers Construction project site for {{ProjectName}} ({{ClientName}})",
+      "locale": 1033,
+      "hubSiteAssociation": "https://hedrickbrothers.sharepoint.com/sites/HBCHub"
+    },
+    "documentLibraries": [
+      {
+        "title": "00_Project_Admin",
+        "folders": [
+          "Contracts",
+          "Contracts/Templates",
+          "Change_Orders",
+          "Insurance",
+          "Permits",
+          "RFI",
+          "Submittals",
+          "Meeting_Minutes",
+          "Turnover",
+          "Team_Files"
+        ]
+      },
+      {
+        "title": "01_Preconstruction",
+        "folders": [
+          "Proposals",
+          "Estimates",
+          "01_FinalDeliver",
+          "02_PlansSpecs",
+          "03_Assemblies",
+          "04_Takeoff",
+          "05_Addenda",
+          "06_RFI",
+          "07_ScopeLetters",
+          "08_Qualifications",
+          "09_SubBids",
+          "10_BidTabulation",
+          "11_ValueEngineering",
+          "12_ProjectTurnover",
+          "Value_Engineering",
+          "Team_Files"
+        ]
+      },
+      {
+        "title": "02_Safety",
+        "folders": [
+          "Plans",
+          "Inspections",
+          "Incidents",
+          "Team_Files"
+        ]
+      },
+      {
+        "title": "03_Quality_Control",
+        "folders": [
+          "Inspections",
+          "Reports",
+          "Team_Files"
+        ]
+      },
+      {
+        "title": "04_Design",
+        "folders": [
+          "Drawings",
+          "Specifications",
+          "Finish_Schedules",
+          "Team_Files"
+        ]
+      },
+      {
+        "title": "05_Budget",
+        "folders": [
+          "Cost_Reports",
+          "Pay_Applications",
+          "Team_Files"
+        ]
+      },
+      {
+        "title": "10_Scheduling",
+        "folders": [
+          "Baseline",
+          "Updates",
+          "Team_Files"
+        ]
+      },
+      {
+        "title": "20_Field_Operations",
+        "folders": [
+          "Daily_Reports",
+          "Photos",
+          "Team_Files"
+        ]
+      },
+      {
+        "title": "30_Subcontracts",
+        "folders": [
+          "Div_01_General",
+          "Div_01_General/CCO",
+          "Div_01_General/Compliance",
+          "Div_01_General/Contract",
+          "Div_01_General/Proposals",
+          "Div_02_Existing_Conditions",
+          "Div_02_Existing_Conditions/CCO",
+          "Div_02_Existing_Conditions/Compliance",
+          "Div_02_Existing_Conditions/Contract",
+          "Div_02_Existing_Conditions/Proposals",
+          "Div_03_Concrete",
+          "Div_03_Concrete/CCO",
+          "Div_03_Concrete/Compliance",
+          "Div_03_Concrete/Contract",
+          "Div_03_Concrete/Proposals",
+          "Div_04_Masonry",
+          "Div_04_Masonry/CCO",
+          "Div_04_Masonry/Compliance",
+          "Div_04_Masonry/Contract",
+          "Div_04_Masonry/Proposals",
+          "Div_05_Metals",
+          "Div_05_Metals/CCO",
+          "Div_05_Metals/Compliance",
+          "Div_05_Metals/Contract",
+          "Div_05_Metals/Proposals",
+          "Div_06_Wood_Plastics",
+          "Div_06_Wood_Plastics/CCO",
+          "Div_06_Wood_Plastics/Compliance",
+          "Div_06_Wood_Plastics/Contract",
+          "Div_06_Wood_Plastics/Proposals",
+          "Div_07_Thermal_Moisture",
+          "Div_07_Thermal_Moisture/CCO",
+          "Div_07_Thermal_Moisture/Compliance",
+          "Div_07_Thermal_Moisture/Contract",
+          "Div_07_Thermal_Moisture/Proposals",
+          "Div_08_Openings",
+          "Div_08_Openings/CCO",
+          "Div_08_Openings/Compliance",
+          "Div_08_Openings/Contract",
+          "Div_08_Openings/Proposals",
+          "Div_09_Finishes",
+          "Div_09_Finishes/CCO",
+          "Div_09_Finishes/Compliance",
+          "Div_09_Finishes/Contract",
+          "Div_09_Finishes/Proposals",
+          "Div_10_Specialties",
+          "Div_10_Specialties/CCO",
+          "Div_10_Specialties/Compliance",
+          "Div_10_Specialties/Contract",
+          "Div_10_Specialties/Proposals",
+          "Div_11_Equipment",
+          "Div_11_Equipment/CCO",
+          "Div_11_Equipment/Compliance",
+          "Div_11_Equipment/Contract",
+          "Div_11_Equipment/Proposals",
+          "Div_12_Furnishings",
+          "Div_12_Furnishings/CCO",
+          "Div_12_Furnishings/Compliance",
+          "Div_12_Furnishings/Contract",
+          "Div_12_Furnishings/Proposals",
+          "Div_13_Special_Construction",
+          "Div_13_Special_Construction/CCO",
+          "Div_13_Special_Construction/Compliance",
+          "Div_13_Special_Construction/Contract",
+          "Div_13_Special_Construction/Proposals",
+          "Div_14_Conveying",
+          "Div_14_Conveying/CCO",
+          "Div_14_Conveying/Compliance",
+          "Div_14_Conveying/Contract",
+          "Div_14_Conveying/Proposals",
+          "Div_21_Fire_Suppression",
+          "Div_21_Fire_Suppression/CCO",
+          "Div_21_Fire_Suppression/Compliance",
+          "Div_21_Fire_Suppression/Contract",
+          "Div_21_Fire_Suppression/Proposals",
+          "Div_22_Plumbing",
+          "Div_22_Plumbing/CCO",
+          "Div_22_Plumbing/Compliance",
+          "Div_22_Plumbing/Contract",
+          "Div_22_Plumbing/Proposals",
+          "Div_23_HVAC",
+          "Div_23_HVAC/CCO",
+          "Div_23_HVAC/Compliance",
+          "Div_23_HVAC/Contract",
+          "Div_23_HVAC/Proposals",
+          "Div_26_Electrical",
+          "Div_26_Electrical/CCO",
+          "Div_26_Electrical/Compliance",
+          "Div_26_Electrical/Contract",
+          "Div_26_Electrical/Proposals",
+          "Div_27_Communications",
+          "Div_27_Communications/CCO",
+          "Div_27_Communications/Compliance",
+          "Div_27_Communications/Contract",
+          "Div_27_Communications/Proposals",
+          "Div_28_Electronic_Safety",
+          "Div_28_Electronic_Safety/CCO",
+          "Div_28_Electronic_Safety/Compliance",
+          "Div_28_Electronic_Safety/Contract",
+          "Div_28_Electronic_Safety/Proposals",
+          "Div_31_Earthwork",
+          "Div_31_Earthwork/CCO",
+          "Div_31_Earthwork/Compliance",
+          "Div_31_Earthwork/Contract",
+          "Div_31_Earthwork/Proposals",
+          "Div_32_Exterior_Improvements",
+          "Div_32_Exterior_Improvements/CCO",
+          "Div_32_Exterior_Improvements/Compliance",
+          "Div_32_Exterior_Improvements/Contract",
+          "Div_32_Exterior_Improvements/Proposals",
+          "Div_33_Utilities",
+          "Div_33_Utilities/CCO",
+          "Div_33_Utilities/Compliance",
+          "Div_33_Utilities/Contract",
+          "Div_33_Utilities/Proposals",
+          "Team_Files"
+        ]
+      },
+      {
+        "title": "40_Closeout",
+        "folders": [
+          "00_Closeout_Checklist",
+          "01_Punch_List",
+          "02_Certificate_of_Occupancy",
+          "03_Certificate_of_Substantial_Completion",
+          "04_Final_Lien_Waivers",
+          "05_Consent_of_Surety",
+          "06_Final_Change_Order_Log",
+          "07_As_Builts",
+          "08_O_and_M_Manuals",
+          "09_Warranties",
+          "10_Attic_Stock",
+          "11_Keys_and_Access",
+          "12_Training_Records",
+          "13_Final_Inspections",
+          "14_Utility_Transfers",
+          "15_Retention_Release",
+          "Team_Files"
+        ]
+      },
+      {
+        "title": "50_Marketing",
+        "folders": [
+          "Photos",
+          "Awards",
+          "Case_Studies",
+          "Team_Files"
+        ]
+      },
+      {
+        "title": "60_Media",
+        "folders": [
+          "Renderings",
+          "Drone",
+          "Video",
+          "Team_Files"
+        ]
+      },
+      {
+        "title": "70_3rd_Party",
+        "folders": [
+          "Architect",
+          "Architect/Correspondence",
+          "Architect/Drawings",
+          "Architect/Specifications",
+          "Engineer",
+          "Engineer/Civil",
+          "Engineer/MEP",
+          "Engineer/Structural",
+          "Owner",
+          "Owner/Correspondence",
+          "Owner/Notices",
+          "Owner/OCIP",
+          "Owner/Regulatory",
+          "Team_Files"
+        ]
+      }
+    ],
+    "securityGroups": [
+      {
+        "name": "{{ProjectCode}}_Owners",
+        "description": "Full control for project {{ProjectCode}}",
+        "permissionLevel": "Full Control",
+        "memberRoles": ["Executive Leadership", "BD Representative"]
+      },
+      {
+        "name": "{{ProjectCode}}_Members",
+        "description": "Contribute access for project {{ProjectCode}}",
+        "permissionLevel": "Contribute",
+        "memberRoles": ["Preconstruction Team", "Operations Team", "Estimating Coordinator"]
+      },
+      {
+        "name": "{{ProjectCode}}_Visitors",
+        "description": "Read-only access for project {{ProjectCode}}",
+        "permissionLevel": "Read",
+        "memberRoles": ["Marketing", "Legal", "Accounting Manager", "Risk Management", "Quality Control", "Safety"]
+      }
+    ],
+    "lists": [
+      {
+        "title": "Project_Info",
+        "template": "GenericList",
+        "fields": [
+          { "name": "ProjectCode", "type": "Text" },
+          { "name": "ProjectName", "type": "Text" },
+          { "name": "ClientName", "type": "Text" },
+          { "name": "Division", "type": "Choice" },
+          { "name": "Region", "type": "Choice" },
+          { "name": "Sector", "type": "Choice" },
+          { "name": "ProjectValue", "type": "Currency" },
+          { "name": "SquareFeet", "type": "Number" },
+          { "name": "SiteURL", "type": "URL" }
+        ]
+      },
+      {
+        "title": "Team_Members",
+        "template": "GenericList",
+        "fields": [
+          { "name": "MemberName", "type": "Person" },
+          { "name": "Role", "type": "Choice" },
+          { "name": "StartDate", "type": "DateTime" }
+        ]
+      },
+      {
+        "title": "Deliverables",
+        "template": "GenericList",
+        "fields": [
+          { "name": "Title", "type": "Text" },
+          { "name": "Status", "type": "Choice" },
+          { "name": "DueDate", "type": "DateTime" },
+          { "name": "AssignedTo", "type": "Person" },
+          { "name": "Priority", "type": "Choice" }
+        ]
+      },
+      {
+        "title": "Action_Items",
+        "template": "GenericList",
+        "fields": [
+          { "name": "Title", "type": "Text" },
+          { "name": "Status", "type": "Choice" },
+          { "name": "DueDate", "type": "DateTime" },
+          { "name": "AssignedTo", "type": "Person" },
+          { "name": "Priority", "type": "Choice" }
+        ]
+      },
+      {
+        "title": "Turnover_Checklist",
+        "template": "GenericList",
+        "fields": [
+          { "name": "Title", "type": "Text" },
+          { "name": "Category", "type": "Choice" },
+          { "name": "Status", "type": "Choice" },
+          { "name": "CompletedDate", "type": "DateTime" },
+          { "name": "CompletedBy", "type": "Person" }
+        ]
+      }
+    ]
+  }
+}

--- a/src/webparts/hbcProjectControls/services/IDataService.ts
+++ b/src/webparts/hbcProjectControls/services/IDataService.ts
@@ -6,6 +6,7 @@ import { IFeatureFlag } from '../models/IFeatureFlag';
 import { IMeeting, ICalendarAvailability } from '../models/IMeeting';
 import { INotification } from '../models/INotification';
 import { IAuditEntry } from '../models/IAuditEntry';
+import { IProvisioningLog } from '../models/IProvisioningLog';
 import { GoNoGoDecision, Stage } from '../models/enums';
 
 export interface IListQueryOptions {
@@ -73,9 +74,11 @@ export interface IDataService {
   getAuditLog(entityType?: string, entityId?: string): Promise<IAuditEntry[]>;
 
   // Provisioning
-  triggerProvisioning(leadId: number, projectCode: string): Promise<{ status: string; logId: number }>;
-  getProvisioningStatus(projectCode: string): Promise<{ status: string; step: number; error?: string }>;
-  retryProvisioning(projectCode: string, fromStep: number): Promise<void>;
+  triggerProvisioning(leadId: number, projectCode: string, projectName: string, requestedBy: string): Promise<IProvisioningLog>;
+  getProvisioningStatus(projectCode: string): Promise<IProvisioningLog | null>;
+  updateProvisioningLog(projectCode: string, data: Partial<IProvisioningLog>): Promise<IProvisioningLog>;
+  getProvisioningLogs(): Promise<IProvisioningLog[]>;
+  retryProvisioning(projectCode: string, fromStep: number): Promise<IProvisioningLog>;
 
   // App Context
   getAppContextConfig(siteUrl: string): Promise<{ RenderMode: string; AppTitle: string; VisibleModules: string[] } | null>;

--- a/src/webparts/hbcProjectControls/services/ProvisioningService.ts
+++ b/src/webparts/hbcProjectControls/services/ProvisioningService.ts
@@ -1,0 +1,155 @@
+import { IDataService } from './IDataService';
+import { IProvisioningLog, ProvisioningStatus, PROVISIONING_STEPS, TOTAL_PROVISIONING_STEPS } from '../models';
+
+export interface IProvisioningInput {
+  leadId: number;
+  projectCode: string;
+  projectName: string;
+  clientName: string;
+  division: string;
+  region: string;
+  requestedBy: string;
+}
+
+const STEP_DELAY_MS = 500;
+
+export class ProvisioningService {
+  private dataService: IDataService;
+
+  constructor(dataService: IDataService) {
+    this.dataService = dataService;
+  }
+
+  /**
+   * Kick off the full 7-step provisioning sequence.
+   * In mock mode each step simulates with a 500ms delay.
+   * Returns the initial provisioning log; consumers should poll
+   * getProvisioningStatus() for progress updates.
+   */
+  public async provisionSite(input: IProvisioningInput): Promise<IProvisioningLog> {
+    // Create the provisioning log entry
+    const log = await this.dataService.triggerProvisioning(
+      input.leadId,
+      input.projectCode,
+      input.projectName,
+      input.requestedBy
+    );
+
+    // Run steps asynchronously so the caller can poll for status
+    this.runSteps(input).catch(console.error);
+
+    return log;
+  }
+
+  /**
+   * Run through provisioning steps sequentially.
+   * Updates the provisioning log at each step.
+   */
+  private async runSteps(input: IProvisioningInput): Promise<void> {
+    const { projectCode } = input;
+    const siteUrl = `https://hedrickbrothers.sharepoint.com/sites/${projectCode.replace(/-/g, '')}`;
+
+    for (let step = 1; step <= TOTAL_PROVISIONING_STEPS; step++) {
+      // Mark step as in-progress
+      await this.dataService.updateProvisioningLog(projectCode, {
+        status: ProvisioningStatus.InProgress,
+        currentStep: step,
+        completedSteps: step - 1,
+      });
+
+      // Simulate step work
+      await this.simulateStep(step);
+
+      // Mark step completed
+      await this.dataService.updateProvisioningLog(projectCode, {
+        currentStep: step,
+        completedSteps: step,
+      });
+    }
+
+    // All steps done — mark completed with site URL
+    await this.dataService.updateProvisioningLog(projectCode, {
+      status: ProvisioningStatus.Completed,
+      currentStep: TOTAL_PROVISIONING_STEPS,
+      completedSteps: TOTAL_PROVISIONING_STEPS,
+      siteUrl,
+      completedAt: new Date().toISOString(),
+    });
+
+    // Update the lead with the site URL
+    const log = await this.dataService.getProvisioningStatus(projectCode);
+    if (log) {
+      await this.dataService.updateLead(log.leadId, { ProjectSiteURL: siteUrl });
+    }
+  }
+
+  /**
+   * Simulate a single provisioning step with a delay.
+   */
+  private simulateStep(_step: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, STEP_DELAY_MS));
+  }
+
+  /**
+   * Retry provisioning from a specific failed step.
+   */
+  public async retryFromStep(projectCode: string, fromStep: number): Promise<IProvisioningLog> {
+    const log = await this.dataService.retryProvisioning(projectCode, fromStep);
+
+    // Resume steps from the failed step
+    const currentLog = await this.dataService.getProvisioningStatus(projectCode);
+    if (currentLog) {
+      this.resumeSteps(projectCode, fromStep).catch(console.error);
+    }
+
+    return log;
+  }
+
+  /**
+   * Resume step execution from a given step number.
+   */
+  private async resumeSteps(projectCode: string, fromStep: number): Promise<void> {
+    for (let step = fromStep; step <= TOTAL_PROVISIONING_STEPS; step++) {
+      await this.dataService.updateProvisioningLog(projectCode, {
+        status: ProvisioningStatus.InProgress,
+        currentStep: step,
+        completedSteps: step - 1,
+      });
+
+      await this.simulateStep(step);
+
+      await this.dataService.updateProvisioningLog(projectCode, {
+        currentStep: step,
+        completedSteps: step,
+      });
+    }
+
+    const siteUrl = `https://hedrickbrothers.sharepoint.com/sites/${projectCode.replace(/-/g, '')}`;
+    await this.dataService.updateProvisioningLog(projectCode, {
+      status: ProvisioningStatus.Completed,
+      currentStep: TOTAL_PROVISIONING_STEPS,
+      completedSteps: TOTAL_PROVISIONING_STEPS,
+      siteUrl,
+      completedAt: new Date().toISOString(),
+    });
+
+    const log = await this.dataService.getProvisioningStatus(projectCode);
+    if (log) {
+      await this.dataService.updateLead(log.leadId, { ProjectSiteURL: siteUrl });
+    }
+  }
+
+  /**
+   * Get current provisioning status.
+   */
+  public async getProvisioningStatus(projectCode: string): Promise<IProvisioningLog | null> {
+    return this.dataService.getProvisioningStatus(projectCode);
+  }
+
+  /**
+   * Get the step labels for display.
+   */
+  public static getStepLabels(): readonly { step: number; label: string }[] {
+    return PROVISIONING_STEPS;
+  }
+}

--- a/src/webparts/hbcProjectControls/services/SharePointDataService.ts
+++ b/src/webparts/hbcProjectControls/services/SharePointDataService.ts
@@ -7,6 +7,7 @@ import { IFeatureFlag } from '../models/IFeatureFlag';
 import { IMeeting, ICalendarAvailability } from '../models/IMeeting';
 import { INotification } from '../models/INotification';
 import { IAuditEntry } from '../models/IAuditEntry';
+import { IProvisioningLog } from '../models/IProvisioningLog';
 import { GoNoGoDecision, Stage } from '../models/enums';
 import { LIST_NAMES } from '../utils/constants';
 
@@ -212,21 +213,32 @@ export class SharePointDataService implements IDataService {
   }
 
   // --- Provisioning ---
-  async triggerProvisioning(_leadId: number, _projectCode: string): Promise<{ status: string; logId: number }> {
+  async triggerProvisioning(_leadId: number, _projectCode: string, _projectName: string, _requestedBy: string): Promise<IProvisioningLog> {
     // Delegated to PowerAutomateService
     throw new Error('Use PowerAutomateService directly');
   }
 
-  async getProvisioningStatus(projectCode: string): Promise<{ status: string; step: number; error?: string }> {
+  async getProvisioningStatus(projectCode: string): Promise<IProvisioningLog | null> {
     const items = await this.sp.web.lists.getByTitle(LIST_NAMES.PROVISIONING_LOG).items
       .filter(`ProjectCode eq '${projectCode}'`)
       .orderBy('RequestedAt', false)
       .top(1)();
-    if (items.length === 0) return { status: 'NotFound', step: 0 };
-    return { status: items[0].Status, step: items[0].StepCompleted || 0, error: items[0].ErrorMessage };
+    if (items.length === 0) return null;
+    return items[0] as IProvisioningLog;
   }
 
-  async retryProvisioning(_projectCode: string, _fromStep: number): Promise<void> {
+  async updateProvisioningLog(_projectCode: string, _data: Partial<IProvisioningLog>): Promise<IProvisioningLog> {
+    throw new Error('Use PowerAutomateService directly');
+  }
+
+  async getProvisioningLogs(): Promise<IProvisioningLog[]> {
+    const items = await this.sp.web.lists.getByTitle(LIST_NAMES.PROVISIONING_LOG).items
+      .orderBy('RequestedAt', false)
+      .top(100)();
+    return items as IProvisioningLog[];
+  }
+
+  async retryProvisioning(_projectCode: string, _fromStep: number): Promise<IProvisioningLog> {
     // Delegated to PowerAutomateService
     throw new Error('Use PowerAutomateService directly');
   }

--- a/src/webparts/hbcProjectControls/services/index.ts
+++ b/src/webparts/hbcProjectControls/services/index.ts
@@ -12,3 +12,5 @@ export { PowerAutomateService } from './PowerAutomateService';
 export type { IProvisioningPayload } from './PowerAutomateService';
 export { NotificationService } from './NotificationService';
 export type { INotificationContext } from './NotificationService';
+export { ProvisioningService } from './ProvisioningService';
+export type { IProvisioningInput } from './ProvisioningService';


### PR DESCRIPTION
## Summary
- **ProvisioningService** orchestrating a 7-step async provisioning sequence (Create site → PnP template → Hub association → Security groups → Copy templates → Copy lead data → Update Leads_Master). Mock mode simulates each step with 500ms delays and status updates.
- **IProvisioningLog** model with full step tracking: id, projectCode, projectName, leadId, status, currentStep, completedSteps, failedStep, errorMessage, retryCount, siteUrl, requestedBy/At/completedAt.
- **ProvisioningStatus** shared component — vertical stepper with real-time polling, color-coded step indicators (green check/blue current/red failed), error display, and site URL link on completion.
- **AdminPanel** at `/admin` — DataTable showing all provisioning requests with status badges, progress, error messages, retry counts, and a Retry button for failed entries. Expandable detail view with full stepper. RBAC-gated to Executive Leadership and IDS.
- **PnP site-template.json** — Complete project site definition: 13 document libraries with CSI division subfolders (CCO/Compliance/Contract/Proposals), Estimating subfolders (01–12), Closeout numbered folders (00–15), 3rd Party folders (Architect/Engineer/Owner), 3 security groups, and 5 SharePoint lists.
- **GO decision flow** wired end-to-end: GoNoGoScorecard triggers `provisionSite()` on GO → inline stepper shows progress → LeadDetailPage shows provisioning status or project site link on completion.

## New Files
- `models/IProvisioningLog.ts`
- `services/ProvisioningService.ts`
- `provisioning/site-template.json`
- `components/shared/ProvisioningStatus.tsx`
- `components/pages/hub/AdminPanel.tsx`

## Modified Files
- `services/IDataService.ts` — Enhanced provisioning interface (returns IProvisioningLog, added updateProvisioningLog/getProvisioningLogs)
- `services/MockDataService.ts` — Replaced basic Map with IProvisioningLog[] array, full 7-step support
- `services/SharePointDataService.ts` — Updated stubs to match new interface
- `services/index.ts`, `models/index.ts`, `shared/index.ts`, `hub/index.ts` — Barrel exports
- `App.tsx` — Added `/admin` route
- `GoNoGoScorecard.tsx` — GO path triggers provisioning, shows inline stepper
- `LeadDetailPage.tsx` — Shows provisioning status or site link for GO leads

## Test plan
- [ ] Verify `tsc --noEmit` passes with 0 errors
- [ ] Verify `gulp build` succeeds
- [ ] Navigate to a GoNoGo-Pending lead, score it, and submit a GO decision with project code
- [ ] Confirm provisioning stepper appears and progresses through all 7 steps
- [ ] After completion, verify LeadDetailPage shows the project site URL link
- [ ] Navigate to `/admin` and confirm provisioning log appears in the DataTable
- [ ] Verify admin panel shows correct status, progress, and timestamps
- [ ] Verify the Retry button appears for failed/partial-failure entries
- [ ] Confirm PnP site-template.json contains all 13 document libraries with complete subfolder structure
- [ ] Confirm admin panel is access-restricted (non-admin roles see "Access Restricted")

🤖 Generated with [Claude Code](https://claude.com/claude-code)