### PR TITLE
Add render mode switcher to dev server toolbar

### DIFF
--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -6,33 +6,111 @@ import { RenderMode } from '@models/enums';
 
 const dataService = new MockDataService();
 
-const DevBadge: React.FC = () => (
-  <div
-    style={{
-      position: 'fixed',
-      bottom: 12,
-      right: 12,
-      padding: '4px 12px',
-      background: 'rgba(232, 119, 34, 0.85)',
-      color: '#fff',
-      fontSize: 11,
-      fontWeight: 700,
-      borderRadius: 4,
-      zIndex: 9999,
-      letterSpacing: 1,
-      pointerEvents: 'none',
-      userSelect: 'none',
-    }}
-  >
-    DEV PREVIEW
-  </div>
-);
+const MODE_OPTIONS: { label: string; mode: RenderMode }[] = [
+  { label: 'Hub', mode: RenderMode.Full },
+  { label: 'Project', mode: RenderMode.Project },
+  { label: 'Precon', mode: RenderMode.Standalone },
+];
 
-const Root: React.FC = () => (
-  <>
-    <App dataService={dataService} renderMode={RenderMode.Full} />
-    <DevBadge />
-  </>
-);
+const DevToolbar: React.FC<{
+  mode: RenderMode;
+  onModeChange: (mode: RenderMode) => void;
+}> = ({ mode, onModeChange }) => {
+  const [hovered, setHovered] = React.useState<RenderMode | null>(null);
 
-ReactDOM.render(<Root />, document.getElementById('root'));
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 12,
+        right: 12,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0,
+        background: 'rgba(27, 42, 74, 0.92)',
+        borderRadius: 6,
+        boxShadow: '0 2px 12px rgba(0,0,0,0.25)',
+        zIndex: 9999,
+        userSelect: 'none',
+        padding: '0 4px 0 12px',
+        height: 34,
+      }}
+    >
+      <span
+        style={{
+          color: '#fff',
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: 1,
+          marginRight: 10,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        DEV PREVIEW
+      </span>
+      <div
+        style={{
+          width: 1,
+          height: 18,
+          background: 'rgba(255,255,255,0.25)',
+          marginRight: 6,
+        }}
+      />
+      <div style={{ display: 'flex', gap: 3, padding: '3px 0' }}>
+        {MODE_OPTIONS.map(({ label, mode: optMode }) => {
+          const isActive = optMode === mode;
+          const isHover = optMode === hovered && !isActive;
+          return (
+            <button
+              key={optMode}
+              onClick={() => onModeChange(optMode)}
+              onMouseEnter={() => setHovered(optMode)}
+              onMouseLeave={() => setHovered(null)}
+              style={{
+                border: isActive ? 'none' : '1px solid rgba(255,255,255,0.2)',
+                borderRadius: 4,
+                padding: '2px 10px',
+                fontSize: 11,
+                fontWeight: isActive ? 700 : 500,
+                cursor: isActive ? 'default' : 'pointer',
+                background: isActive
+                  ? '#E87722'
+                  : isHover
+                    ? 'rgba(255,255,255,0.1)'
+                    : 'transparent',
+                color: isActive ? '#fff' : 'rgba(255,255,255,0.7)',
+                outline: 'none',
+                transition: 'background 0.15s, color 0.15s',
+                lineHeight: '20px',
+              }}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+const DevRoot: React.FC = () => {
+  const [mode, setMode] = React.useState<RenderMode>(RenderMode.Full);
+
+  const handleModeChange = React.useCallback(
+    (newMode: RenderMode) => {
+      if (newMode === mode) return;
+      window.location.hash = '#/';
+      setMode(newMode);
+    },
+    [mode]
+  );
+
+  return (
+    <>
+      <App key={mode} dataService={dataService} renderMode={mode} />
+      <DevToolbar mode={mode} onModeChange={handleModeChange} />
+    </>
+  );
+};
+
+ReactDOM.render(<DevRoot />, document.getElementById('root'));


### PR DESCRIPTION
## Summary
- Replace the static DEV PREVIEW badge with an interactive **DevToolbar** featuring Hub / Project / Precon mode buttons
- Developers can now switch render modes from the browser without editing source code
- Uses `key={mode}` on `<App>` to force a clean unmount/remount and resets the hash route on mode change to prevent stale deep routes

## Test plan
- [ ] Run `npm run dev` — Hub mode loads by default with HubNav sidebar
- [ ] Click **Precon** — App remounts with PreconNav and EstimatingDashboard
- [ ] Click **Project** — App remounts with ProjectNav and ProjectDashboard
- [ ] Click **Hub** — Returns to Hub mode, route resets to `/`
- [ ] Navigate to a deep route (e.g. `/lead/1/gonogo`), switch modes — app resets to `/` cleanly
- [ ] Toolbar stays visible and correctly highlights the active mode in all three modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)