### PR TITLE
Add dev server role switcher and fix project mode accessibility

### DIFF
--- a/dev/RoleSwitcher.tsx
+++ b/dev/RoleSwitcher.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react';
+import { RoleName } from '@models/enums';
+
+const ROLE_OPTIONS: { label: string; value: RoleName }[] = [
+  { label: 'BD Representative', value: RoleName.BDRepresentative },
+  { label: 'Estimating Coordinator', value: RoleName.EstimatingCoordinator },
+  { label: 'Accounting Manager', value: RoleName.AccountingManager },
+  { label: 'Preconstruction Team', value: RoleName.PreconstructionTeam },
+  { label: 'Operations Team', value: RoleName.OperationsTeam },
+  { label: 'Executive Leadership', value: RoleName.ExecutiveLeadership },
+  { label: 'Legal', value: RoleName.Legal },
+  { label: 'Risk Management', value: RoleName.RiskManagement },
+  { label: 'Marketing', value: RoleName.Marketing },
+  { label: 'Quality Control', value: RoleName.QualityControl },
+  { label: 'Safety', value: RoleName.Safety },
+  { label: 'IDS', value: RoleName.IDS },
+];
+
+export const RoleSwitcher: React.FC<{
+  role: RoleName;
+  onRoleChange: (role: RoleName) => void;
+}> = ({ role, onRoleChange }) => {
+  const [isHovered, setIsHovered] = React.useState(false);
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 12,
+        left: 12,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        background: isHovered
+          ? 'rgba(27, 42, 74, 0.97)'
+          : 'rgba(27, 42, 74, 0.92)',
+        borderRadius: 6,
+        boxShadow: '0 2px 12px rgba(0,0,0,0.25)',
+        zIndex: 9999,
+        userSelect: 'none',
+        padding: '0 10px 0 10px',
+        height: 34,
+        transition: 'background 0.15s',
+      }}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      {/* User icon */}
+      <span
+        style={{
+          fontSize: 13,
+          lineHeight: '34px',
+          flexShrink: 0,
+        }}
+      >
+        &#128100;
+      </span>
+
+      {/* Role pill badge */}
+      <span
+        style={{
+          display: 'inline-block',
+          background: '#E87722',
+          color: '#fff',
+          fontSize: 10,
+          fontWeight: 700,
+          borderRadius: 10,
+          padding: '2px 8px',
+          lineHeight: '16px',
+          whiteSpace: 'nowrap',
+          letterSpacing: 0.3,
+        }}
+      >
+        {role}
+      </span>
+
+      {/* Divider */}
+      <div
+        style={{
+          width: 1,
+          height: 18,
+          background: 'rgba(255,255,255,0.25)',
+          flexShrink: 0,
+        }}
+      />
+
+      {/* Dropdown */}
+      <select
+        value={role}
+        onChange={(e) => onRoleChange(e.target.value as RoleName)}
+        style={{
+          appearance: 'none',
+          WebkitAppearance: 'none',
+          background: 'transparent',
+          border: '1px solid rgba(255,255,255,0.2)',
+          borderRadius: 4,
+          color: 'rgba(255,255,255,0.85)',
+          fontSize: 11,
+          fontWeight: 500,
+          padding: '2px 22px 2px 8px',
+          outline: 'none',
+          cursor: 'pointer',
+          lineHeight: '20px',
+          backgroundImage:
+            "url(\"data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='rgba(255,255,255,0.6)' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E\")",
+          backgroundRepeat: 'no-repeat',
+          backgroundPosition: 'right 6px center',
+        }}
+      >
+        {ROLE_OPTIONS.map(({ label, value }) => (
+          <option
+            key={value}
+            value={value}
+            style={{
+              background: '#1B2A4A',
+              color: '#fff',
+            }}
+          >
+            {label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { App } from '@components/App';
 import { MockDataService } from '@services/MockDataService';
-import { RenderMode } from '@models/enums';
+import { RenderMode, RoleName } from '@models/enums';
+import { RoleSwitcher } from './RoleSwitcher';
+import { setMockUserRole, getMockUserRole } from './mockContext';
 
 const dataService = new MockDataService();
 
@@ -95,6 +97,7 @@ const DevToolbar: React.FC<{
 
 const DevRoot: React.FC = () => {
   const [mode, setMode] = React.useState<RenderMode>(RenderMode.Full);
+  const [role, setRole] = React.useState<RoleName>(getMockUserRole());
 
   const handleModeChange = React.useCallback(
     (newMode: RenderMode) => {
@@ -105,9 +108,21 @@ const DevRoot: React.FC = () => {
     [mode]
   );
 
+  const handleRoleChange = React.useCallback(
+    (newRole: RoleName) => {
+      if (newRole === role) return;
+      setMockUserRole(newRole);
+      dataService.setCurrentUserRole(newRole);
+      window.location.hash = '#/';
+      setRole(newRole);
+    },
+    [role]
+  );
+
   return (
     <>
-      <App key={mode} dataService={dataService} renderMode={mode} />
+      <App key={`${mode}-${role}`} dataService={dataService} renderMode={mode} />
+      <RoleSwitcher role={role} onRoleChange={handleRoleChange} />
       <DevToolbar mode={mode} onModeChange={handleModeChange} />
     </>
   );

--- a/dev/mockContext.ts
+++ b/dev/mockContext.ts
@@ -1,3 +1,21 @@
+import { RoleName } from '@models/enums';
+
+// ---------------------------------------------------------------------------
+// Dev-only mock role state
+// ---------------------------------------------------------------------------
+
+let currentMockRole: RoleName = RoleName.OperationsTeam;
+
+/** Get the currently selected mock role (dev server only). */
+export function getMockUserRole(): RoleName {
+  return currentMockRole;
+}
+
+/** Set the mock role — used by the RoleSwitcher toolbar. */
+export function setMockUserRole(role: RoleName): void {
+  currentMockRole = role;
+}
+
 /**
  * Mock SPFx-like context object.
  * The app code does NOT reference pageContext directly — this exists

--- a/src/webparts/hbcProjectControls/mock/leads.json
+++ b/src/webparts/hbcProjectControls/mock/leads.json
@@ -703,5 +703,30 @@
     "LossReason": "Other",
     "LossNotes": "Client shelved renovation plans after Hurricane Ian insurance reassessment. Project indefinitely delayed. May re-emerge in 2027.",
     "Notes": "Full resort renovation including 200 guest rooms, spa, restaurant, pool deck. Project canceled by owner."
+  },
+  {
+    "id": 29,
+    "Title": "HBC Corporate Office Renovation",
+    "ClientName": "Hedrick Brothers Construction",
+    "AE": "SchenkelShultz Architecture",
+    "CityLocation": "West Palm Beach",
+    "Region": "West Palm Beach",
+    "Sector": "Commercial",
+    "SubSector": "Office Building",
+    "Division": "Commercial",
+    "Originator": "bfetting@hedrickbrothers.com",
+    "DepartmentOfOrigin": "Operations",
+    "DateOfEvaluation": "2025-01-15",
+    "DateSubmitted": "2025-01-10",
+    "SquareFeet": 45000,
+    "ProjectValue": 12500000,
+    "DeliveryMethod": "GMP",
+    "Stage": "Active-Construction",
+    "ProjectCode": "25-042-01",
+    "SiteURL": "https://hedrickbrothers.sharepoint.com/sites/25-042-01",
+    "GoNoGoScore_Originator": 92,
+    "GoNoGoScore_Committee": 90,
+    "GoNoGoDecision": "GO",
+    "Notes": "Internal corporate office renovation project. Full access to all Phase 9/10 features for dev testing."
   }
 ]

--- a/src/webparts/hbcProjectControls/services/MockDataService.ts
+++ b/src/webparts/hbcProjectControls/services/MockDataService.ts
@@ -119,6 +119,14 @@ export class MockDataService implements IDataService {
   private boilerplate: IPMPBoilerplateSection[];
   private nextId: number;
 
+  // Dev-only: overridable role for the RoleSwitcher toolbar
+  private _currentRole: RoleName = RoleName.OperationsTeam;
+
+  /** Set the mock user role (called by the dev RoleSwitcher). */
+  public setCurrentUserRole(role: RoleName): void {
+    this._currentRole = role;
+  }
+
   constructor() {
     this.leads = JSON.parse(JSON.stringify(mockLeads)) as ILead[];
     this.scorecards = JSON.parse(JSON.stringify(mockScorecards)) as IGoNoGoScorecard[];
@@ -525,14 +533,14 @@ export class MockDataService implements IDataService {
   public async getCurrentUser(): Promise<ICurrentUser> {
     await delay();
 
-    const roleName = RoleName.BDRepresentative;
+    const roleName = this._currentRole;
     const perms = ROLE_PERMISSIONS[roleName] ?? [];
 
     return {
       id: 5,
-      displayName: 'Karen Foster',
-      email: 'kfoster@hedrickbrothers.com',
-      loginName: 'i:0#.f|membership|kfoster@hedrickbrothers.com',
+      displayName: 'Dev User',
+      email: 'devuser@hedrickbrothers.com',
+      loginName: 'i:0#.f|membership|devuser@hedrickbrothers.com',
       roles: [roleName],
       permissions: new Set<string>(perms),
       photoUrl: undefined


### PR DESCRIPTION
## Summary

- Add RoleSwitcher toolbar (bottom-left) to switch between all 12 RBAC roles for testing permission-based UI visibility
- Add missing lead entry (25-042-01) to enable Project mode features in dev server
- Update MockDataService to support dynamic role switching via setCurrentUserRole()

## Changes

### Dev Server Enhancements
- **dev/RoleSwitcher.tsx** (new): Floating toolbar with dropdown to select any of the 12 roles, displays current role as orange pill badge
- **dev/mockContext.ts**: Added getMockUserRole/setMockUserRole for module-level role state
- **dev/index.tsx**: Integrated RoleSwitcher with key-based remount pattern (same as mode switcher)

### Mock Data Fix
- **leads.json**: Added lead entry for project code 25-042-01 (Active-Construction stage) to enable all Phase 9/10 project features

### MockDataService
- Added _currentRole instance property and setCurrentUserRole() method
- getCurrentUser() now returns the dynamically selected role instead of hardcoded BDRepresentative

## Test plan

- [ ] Run `npm run dev` and verify role switcher appears in bottom-left
- [ ] Switch to "Marketing" role and verify Operations-only nav items are hidden
- [ ] Switch to "Executive Leadership" and verify admin/approval features are visible
- [ ] Switch to "Project" mode and verify all Phase 9/10 nav items appear
- [ ] Verify `gulp build --ship` passes with 0 errors


Made with [Cursor](https://cursor.com)