### PR TITLE
Lead-to-site workflow enhancement and simplified Go/No-Go decision

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
 ║  Stale documentation is worse than no documentation.                 ║
 ╚══════════════════════════════════════════════════════════════════════╝
 
-**Last Updated:** 2026-02-10 — Phase 20: SharePoint Admin Role + Dev Super-Admin Mode
+**Last Updated:** 2026-02-11 — Phase 22: Lead-to-Site Workflow Enhancement
 
 ---
 
@@ -109,9 +109,10 @@ src/webparts/hbcProjectControls/
 │   │   ├── ProjectRequiredRoute.tsx      # Shows "No Project Selected" if no selectedProject
 │   │   ├── RoleGate.tsx                  # Renders children only if user has allowed role
 │   │   └── index.ts
-│   ├── hooks/                             # 35 custom hooks (see §7 for service method mapping)
+│   ├── hooks/                             # 36 custom hooks (see §7 for service method mapping)
 │   │   ├── useActionInbox.ts             # Action inbox aggregation with auto-refresh
 │   │   ├── useActiveProjects.ts          # Active projects portfolio
+│   │   ├── useAssignmentMappings.ts     # Assignment mapping CRUD + resolution
 │   │   ├── useBuyoutLog.ts              # Buyout log CRUD
 │   │   ├── useCommitmentApproval.ts     # Commitment approval workflow
 │   │   ├── useComplianceLog.ts          # Compliance log with filters
@@ -247,8 +248,8 @@ src/webparts/hbcProjectControls/
 │       ├── WorkflowPreview.tsx
 │       ├── WorkflowStepCard.tsx
 │       └── index.ts
-├── mock/                                  # 40 JSON mock data files (see §12)
-├── models/                                # 44 TypeScript model files (see §6)
+├── mock/                                  # 41 JSON mock data files (see §12)
+├── models/                                # 45 TypeScript model files (see §6)
 │   ├── enums.ts                          # All shared enums (31 enums)
 │   ├── I*.ts                             # Interface files (one per entity)
 │   └── index.ts                          # Barrel export
@@ -363,7 +364,7 @@ sharepoint/solution/debug/          # SPFx solution package output (auto-generat
 | File | src/webparts/hbcProjectControls/components/App.tsx |
 | Component Tree | `FluentProvider` → `ErrorBoundary` → `AppProvider(dataService)` → `HashRouter` → `AppShell` → `AppRoutes` |
 | Router Type | `HashRouter` from react-router-dom |
-| Route Count | 48 routes (see §8) |
+| Route Count | 49 routes (see §8) |
 
 ---
 
@@ -535,6 +536,7 @@ sharepoint/solution/debug/          # SPFx solution package output (auto-generat
 | IProjectType | models/IProjectType.ts | code, label, office | Project_Types | Hub |
 | IStandardCostCode | models/IStandardCostCode.ts | id, description, phase, division, isDefault | Standard_Cost_Codes | Hub |
 | ISectorDefinition | models/ISectorDefinition.ts | id, code, label, isActive, parentDivision?, sortOrder | Sector_Definitions | Hub |
+| IAssignmentMapping | models/IAssignmentMapping.ts | id, region, sector, assignmentType: AssignmentType, assignee: {userId, displayName, email} | Assignment_Mappings | Hub |
 | IWorkflowDefinition | models/IWorkflowDefinition.ts | id, workflowKey, name, description, steps, isActive, lastModifiedBy, lastModifiedDate | Workflow_Definitions | Hub |
 | IWorkflowStep | models/IWorkflowDefinition.ts | id, workflowId, stepOrder, name, assignmentType, projectRole?, defaultAssignee?, conditionalAssignees, isConditional, actionLabel, canChairMeeting? | Workflow_Steps | Hub |
 | IPersonAssignment | models/IWorkflowDefinition.ts | userId, displayName, email | — | — |
@@ -572,14 +574,15 @@ sharepoint/solution/debug/          # SPFx solution package output (auto-generat
 | Division | Commercial, LuxuryResidential |
 | DepartmentOfOrigin | BusinessDevelopment, Estimating, Marketing, Operations, Other |
 | DeliveryMethod | GMP, HardBid, PreconWithGMP, Other |
-| GoNoGoDecision | Go, NoGo, Wait |
+| GoNoGoDecision | Go, NoGo, ConditionalGo |
+| ScorecardStatus | BDDraft, AwaitingDirectorReview, DirectorReturnedForRevision, AwaitingCommitteeScoring, CommitteeReturnedForRevision, Rejected, NoGo, Go, Locked, Unlocked |
 | WinLossDecision | Win, Loss |
 | LossReason | Price, Relationship, Experience, Schedule, Competition, Other |
 | RoleName | BDRepresentative, EstimatingCoordinator, AccountingManager, PreconstructionTeam, OperationsTeam, ExecutiveLeadership, Legal, RiskManagement, Marketing, QualityControl, Safety, IDS, DepartmentDirector, SharePointAdmin |
 | ProvisioningStatus | Queued, InProgress, Completed, PartialFailure, Failed |
 | TurnoverStatus | Draft, PrerequisitesInProgress, MeetingScheduled, MeetingComplete, PendingSignatures, Signed, Complete |
-| AuditAction | LeadCreated, LeadEdited, GoNoGoScoreSubmitted, GoNoGoDecisionMade, SiteProvisioningTriggered, SiteProvisioningCompleted, EstimateCreated, EstimateStatusChanged, TurnoverInitiated, TurnoverCompleted, PermissionChanged, MeetingScheduled, LossRecorded, AutopsyCompleted, ConfigFeatureFlagChanged, ConfigRoleChanged, ChecklistItemUpdated, ChecklistItemAdded, ChecklistSignedOff, MatrixAssignmentChanged, MatrixTaskAdded, ProjectRecordUpdated, ProjectRecordCreated, PMPSubmitted, PMPApproved, PMPReturned, PMPSigned, RiskItemUpdated, QualityConcernUpdated, SafetyConcernUpdated, ScheduleUpdated, SuperPlanUpdated, LessonAdded, MonthlyReviewSubmitted, MonthlyReviewAdvanced, WorkflowStepUpdated, WorkflowConditionAdded, WorkflowConditionRemoved, WorkflowOverrideSet, WorkflowOverrideRemoved, TurnoverAgendaCreated, TurnoverPrerequisiteCompleted, TurnoverItemDiscussed, TurnoverSubcontractorAdded, TurnoverSubcontractorRemoved, TurnoverExhibitReviewed, TurnoverExhibitAdded, TurnoverExhibitRemoved, TurnoverSigned, TurnoverAgendaCompleted, HubNavLinkCreated, HubNavLinkFailed, HubNavLinkRetried, HubNavLinkRemoved, HubSiteUrlUpdated, TemplateCreated, TemplateUpdated, TemplateDeleted, ProjectTeamAssigned, ProjectTeamRemoved, ProjectTeamOverridden, SecurityGroupMappingChanged, PermissionResolved |
-| EntityType | Lead, Scorecard, Estimate, Project, Permission, Config, Checklist, Matrix, ProjectRecord, RiskCost, Quality, Safety, Schedule, SuperintendentPlan, LessonLearned, PMP, MonthlyReview, WorkflowDefinition, TurnoverAgenda, PermissionTemplate, ProjectTeamAssignment |
+| AuditAction | LeadCreated, LeadEdited, GoNoGoScoreSubmitted, GoNoGoDecisionMade, SiteProvisioningTriggered, SiteProvisioningCompleted, EstimateCreated, EstimateStatusChanged, TurnoverInitiated, TurnoverCompleted, PermissionChanged, MeetingScheduled, LossRecorded, AutopsyCompleted, ConfigFeatureFlagChanged, ConfigRoleChanged, ChecklistItemUpdated, ChecklistItemAdded, ChecklistSignedOff, MatrixAssignmentChanged, MatrixTaskAdded, ProjectRecordUpdated, ProjectRecordCreated, PMPSubmitted, PMPApproved, PMPReturned, PMPSigned, RiskItemUpdated, QualityConcernUpdated, SafetyConcernUpdated, ScheduleUpdated, SuperPlanUpdated, LessonAdded, MonthlyReviewSubmitted, MonthlyReviewAdvanced, WorkflowStepUpdated, WorkflowConditionAdded, WorkflowConditionRemoved, WorkflowOverrideSet, WorkflowOverrideRemoved, TurnoverAgendaCreated, TurnoverPrerequisiteCompleted, TurnoverItemDiscussed, TurnoverSubcontractorAdded, TurnoverSubcontractorRemoved, TurnoverExhibitReviewed, TurnoverExhibitAdded, TurnoverExhibitRemoved, TurnoverSigned, TurnoverAgendaCompleted, HubNavLinkCreated, HubNavLinkFailed, HubNavLinkRetried, HubNavLinkRemoved, HubSiteUrlUpdated, TemplateCreated, TemplateUpdated, TemplateDeleted, ProjectTeamAssigned, ProjectTeamRemoved, ProjectTeamOverridden, SecurityGroupMappingChanged, PermissionResolved, ScorecardArchived, LeadFolderCreated, AssignmentMappingUpdated |
+| EntityType | Lead, Scorecard, Estimate, Project, Permission, Config, Checklist, Matrix, ProjectRecord, RiskCost, Quality, Safety, Schedule, SuperintendentPlan, LessonLearned, PMP, MonthlyReview, WorkflowDefinition, TurnoverAgenda, PermissionTemplate, ProjectTeamAssignment, AssignmentMapping |
 | DeliverableStatus | NotStarted, InProgress, InReview, Complete |
 | ActionItemStatus | Open, InProgress, Complete |
 | Priority | Low, Medium, High, Critical |
@@ -590,7 +593,7 @@ sharepoint/solution/debug/          # SPFx solution package output (auto-generat
 | MeetingType | GoNoGo, Kickoff, PreconKickoff, RedTeam, WinStrategy, Autopsy, LossAutopsy, Turnover, Other |
 | NotificationType | Email, Teams, Both |
 | ActiveProjectStatus | Precon, Construction, FinalPayment |
-| NotificationEvent | LeadSubmitted, GoNoGoScoringRequested, GoNoGoDecisionMade, SiteProvisioned, PreconKickoff, DeliverableDueApproaching, WinLossRecorded, AutopsyScheduled, TurnoverCompleted, SafetyFolderChanged, PMPSignatureRequested, PMPSubmittedForApproval, PMPApprovalRequired, PMPApproved, PMPReturnedForRevision, MonthlyReviewDueNotification, MonthlyReviewSubmittedToPX, MonthlyReviewReturnedToPM, MonthlyReviewSubmittedToLeadership, JobNumberRequested, JobNumberAssigned, EstimatingKickoffScheduled, AutopsyFinalized, CommitmentSubmitted, CommitmentWaiverRequired, CommitmentApproved, CommitmentEscalatedToCFO, CommitmentRejected |
+| NotificationEvent | LeadSubmitted, GoNoGoScoringRequested, GoNoGoDecisionMade, SiteProvisioned, PreconKickoff, DeliverableDueApproaching, WinLossRecorded, AutopsyScheduled, TurnoverCompleted, SafetyFolderChanged, PMPSignatureRequested, PMPSubmittedForApproval, PMPApprovalRequired, PMPApproved, PMPReturnedForRevision, MonthlyReviewDueNotification, MonthlyReviewSubmittedToPX, MonthlyReviewReturnedToPM, MonthlyReviewSubmittedToLeadership, JobNumberRequested, JobNumberAssigned, EstimatingKickoffScheduled, AutopsyFinalized, CommitmentSubmitted, CommitmentWaiverRequired, CommitmentApproved, CommitmentEscalatedToCFO, CommitmentRejected, ScorecardSubmittedToDirector, ScorecardReturnedByDirector, ScorecardRejectedByDirector, ScorecardAdvancedToCommittee, ScorecardApprovedGo, ScorecardDecidedNoGo, EstimatingCoordinatorNotifiedGo |
 | WorkflowKey | GO_NO_GO, PMP_APPROVAL, MONTHLY_REVIEW, COMMITMENT_APPROVAL, TURNOVER_APPROVAL |
 | StepAssignmentType | ProjectRole, NamedPerson |
 | ConditionField | Division, Region, Sector |
@@ -635,12 +638,13 @@ sharepoint/solution/debug/          # SPFx solution package output (auto-generat
 | AutopsyAnswer | models/ILossAutopsy.ts | boolean \| null |
 | HubNavLinkStatus | models/IProvisioningLog.ts | 'success' \| 'failed' \| 'not_applicable' |
 | EnvironmentTier | models/IEnvironmentConfig.ts | 'dev' \| 'vetting' \| 'prod' |
+| AssignmentType | models/IAssignmentMapping.ts | 'Estimator' \| 'Director' |
 
 ---
 
 ## §7 Service Methods
 
-192 methods on IDataService. Source: `services/IDataService.ts`
+200 methods on IDataService. Source: `services/IDataService.ts`
 
 | # | Method | Signature | Mock | SP | Hook Caller | Mock JSON |
 |---|--------|-----------|------|-----|-------------|-----------|
@@ -836,6 +840,14 @@ sharepoint/solution/debug/          # SPFx solution package output (auto-generat
 | 190 | getSectorDefinitions | () → Promise<ISectorDefinition[]> | Impl | Stub | useSectorDefinitions | sectorDefinitions.json |
 | 191 | createSectorDefinition | (data: Partial<ISectorDefinition>) → Promise<ISectorDefinition> | Impl | Stub | AdminPanel | sectorDefinitions.json |
 | 192 | updateSectorDefinition | (id: number, data: Partial<ISectorDefinition>) → Promise<ISectorDefinition> | Impl | Stub | AdminPanel | sectorDefinitions.json |
+| 193 | createBdLeadFolder | (leadTitle: string, originatorName: string) → Promise<void> | Impl | Stub | LeadFormPage | in-memory |
+| 194 | checkFolderExists | (path: string) → Promise<boolean> | Impl | Stub | — | in-memory |
+| 195 | createFolder | (path: string) → Promise<void> | Impl | Stub | — | in-memory |
+| 196 | renameFolder | (oldPath: string, newPath: string) → Promise<void> | Impl | Stub | useGoNoGo | in-memory |
+| 197 | getAssignmentMappings | () → Promise<IAssignmentMapping[]> | Impl | Stub | useAssignmentMappings | assignmentMappings.json |
+| 198 | createAssignmentMapping | (data: Partial<IAssignmentMapping>) → Promise<IAssignmentMapping> | Impl | Stub | useAssignmentMappings | assignmentMappings.json |
+| 199 | updateAssignmentMapping | (id: number, data: Partial<IAssignmentMapping>) → Promise<IAssignmentMapping> | Impl | Stub | useAssignmentMappings | assignmentMappings.json |
+| 200 | deleteAssignmentMapping | (id: number) → Promise<void> | Impl | Stub | useAssignmentMappings | assignmentMappings.json |
 
 ---
 
@@ -848,8 +860,9 @@ Source: `components/App.tsx`
 | / | DashboardPage | pages/hub/DashboardPage.tsx | No | — |
 | /marketing | MarketingDashboard | pages/hub/MarketingDashboard.tsx | No | MARKETING_DASHBOARD_VIEW |
 | /preconstruction | EstimatingDashboard | pages/precon/EstimatingDashboard.tsx | No | — |
-| /preconstruction/gonogo | GoNoGoTracker | pages/precon/GoNoGoTracker.tsx | No | — |
 | /preconstruction/pipeline | PipelinePage | pages/hub/PipelinePage.tsx | No | — |
+| /preconstruction/pipeline/gonogo | PipelinePage | pages/hub/PipelinePage.tsx | No | — |
+| /preconstruction/gonogo | PipelinePage | pages/hub/PipelinePage.tsx | No | — |
 | /preconstruction/precon-tracker | EstimatingDashboard | pages/precon/EstimatingDashboard.tsx | No | — |
 | /preconstruction/estimate-log | EstimatingDashboard | pages/precon/EstimatingDashboard.tsx | No | — |
 | /preconstruction/kickoff-list | EstimatingKickoffList | pages/precon/EstimatingKickoffList.tsx | No | KICKOFF_VIEW |
@@ -910,13 +923,13 @@ Marketing                                    [roles: Marketing, Executive Leader
 Preconstruction                              [roles: BD Rep, Estimating Coord, Precon Team, Exec Leadership, Legal]
   ├── Estimating Dashboard                   [/preconstruction]
   ├── Pipeline                               [/preconstruction/pipeline]
-  ├── Go/No-Go Tracker                       [/preconstruction/gonogo]
-  ├── Precon Tracker                          [/preconstruction/precon-tracker]
-  ├── Estimate Log                            [/preconstruction/estimate-log]
+  ├── Go/No-Go Tracker                       [/preconstruction/pipeline/gonogo]
   ├── Kick-Off Checklists                     [/preconstruction/kickoff-list, permission: kickoff:view]
   ├── Post-Bid Autopsies                      [/preconstruction/autopsy-list, permission: autopsy:view]
   ├── New Lead                                [/lead/new, permission: lead:create]
-  ├── Job Number Request                      [/job-request, permission: job_number_request:create]
+  └── Job Number Request                      [/job-request, permission: job_number_request:create]
+─────────────────────────────────────────────
+Accounting                                   [roles: Acct Mgr, Executive Leadership, Dept Director]
   └── Accounting Queue                        [/accounting-queue, permission: accounting_queue:view]
 ─────────────────────────────────────────────
 Operations                                   [roles: Ops Team, Exec Leadership, Risk Mgmt, QC, Safety, IDS]
@@ -964,6 +977,7 @@ Legend: **X** = has permission
 | gonogo:score:committee | | | | | | X | X | | | | | | | X |
 | gonogo:submit | X | | | | | | | | | | | | | X |
 | gonogo:decide | | | | | | X | X | | | | | | | X |
+| gonogo:review | | | | | | X | X | | | | | | | X |
 | gonogo:read | X | X | X | | | X | X | X | X | X | | | | X |
 | precon:read | X | X | X | X | | X | X | X | X | X | X | X | X | X |
 | precon:edit | | X | | X | | | | | | | | | | X |
@@ -987,6 +1001,7 @@ Legend: **X** = has permission
 | admin:config | | | | | | X | | | | | | | X | X |
 | admin:connections | | | | | | X | | | | | | | | X |
 | admin:provisioning | | | | | | X | | | | | | | | X |
+| admin:assignments:manage | | | | | | X | | | | | | | | X |
 | marketing:edit | | | | | | | | | | X | | | | X |
 | marketing:dashboard:view | | | | | | X | X | | | X | | | | X |
 | site:provision | X | | | | | | | | | | | | | X |
@@ -1044,6 +1059,7 @@ Legend: **X** = has permission
 | Marketing | Marketing, Executive Leadership, Department Director, SharePoint Admin |
 | Preconstruction | BD Representative, Estimating Coordinator, Preconstruction Team, Executive Leadership, Department Director, Legal, SharePoint Admin |
 | Operations | Operations Team, Executive Leadership, Department Director, Risk Management, Quality Control, Safety, IDS, SharePoint Admin |
+| Accounting | Accounting Manager, Executive Leadership, Department Director, SharePoint Admin |
 | Admin | Executive Leadership, SharePoint Admin |
 
 ---
@@ -1087,6 +1103,7 @@ Source: `mock/`
 | JSON File | Entity Type | Record Count | Project Codes |
 |-----------|-------------|-------------|---------------|
 | appContextConfig.json | App context configs | 3 | N/A |
+| assignmentMappings.json | IAssignmentMapping | 4 | N/A |
 | buyoutEntries.json | IBuyoutEntry | 15 | 25-042-01 |
 | calendarAvailability.json | ICalendarAvailability | 7 | N/A |
 | closeoutItems.json | ICloseoutItem | 15 | 25-042-01 |
@@ -1169,6 +1186,7 @@ Source: `utils/constants.ts`, `theme/tokens.ts`
   SECURITY_GROUP_MAPPINGS: 'Security_Group_Mappings',
   PROJECT_TEAM_ASSIGNMENTS: 'Project_Team_Assignments',
   SECTOR_DEFINITIONS: 'Sector_Definitions',
+  ASSIGNMENT_MAPPINGS: 'Assignment_Mappings',
 }
 ```
 
@@ -1267,6 +1285,7 @@ Source: `utils/constants.ts`, `theme/tokens.ts`
   PRECON: '/preconstruction',
   PRECON_GONOGO: '/preconstruction/gonogo',
   PRECON_PIPELINE: '/preconstruction/pipeline',
+  PRECON_PIPELINE_GONOGO: '/preconstruction/pipeline/gonogo',
   PRECON_TRACKING: '/preconstruction/precon-tracker',
   PRECON_ESTIMATE_LOG: '/preconstruction/estimate-log',
   PRECON_KICKOFF_LIST: '/preconstruction/kickoff-list',
@@ -1323,6 +1342,10 @@ FILE_CHUNK_SIZE = 10485760  // 10MB
 
 BREAKPOINTS = { mobile: 768, tablet: 1024, desktop: 1024 }
 SPACING = { xs: '4px', sm: '8px', md: '16px', lg: '24px', xl: '32px', xxl: '48px' }
+
+BD_LEADS_SITE_URL = 'https://hedrickbrotherscom.sharepoint.com/sites/PXPortfolioDashboard'
+BD_LEADS_LIBRARY = 'BD Leads'
+BD_LEADS_SUBFOLDERS = ['Client Information', 'Correspondence', 'Proposal Documents', 'Site and Project Plans', 'Financial Estimates', 'Evaluations and Scorecards', 'Contracts and Legal', 'Media and Visuals', 'Archives']
 ```
 
 ### UI Constants (theme/tokens.ts)
@@ -1397,9 +1420,12 @@ TRANSITION = { fast: '150ms ease', normal: '250ms ease', slow: '350ms ease' }
 | 19D | Flexible Sectors + Identity — Dynamic sector definitions replacing hardcoded Sector enum, ISectorDefinition model, admin Sectors tab, identityType on ICurrentUser | models/ISectorDefinition.ts, mock/sectorDefinitions.json, hooks/useSectorDefinitions.ts | models/enums.ts (@deprecated Sector), models/IRole.ts (+identityType), services/IDataService.ts (+3 methods, 192 total), services/MockDataService.ts (+3 implementations), services/SharePointDataService.ts (+3 stubs), pages/hub/AdminPanel.tsx (8 tabs, +Sectors), pages/hub/LeadFormPage.tsx (dynamic sectors), pages/hub/PipelinePage.tsx (dynamic sectors), shared/ConditionBuilder.tsx (dynamic sectors), hooks/index.ts (+1 export), models/index.ts (+1 export), utils/constants.ts (+1 HUB_LIST) |
 | 20 | SharePoint Admin Role + Dev Super-Admin — 14th RoleName (SharePointAdmin) with ALL permissions, Dev Super-Admin mode (union of ALL permissions, dev-only), full admin template (id:9, all 23 tools at ADMIN), resolveUserPermissions super-admin short-circuit + roleToGroupMap entry, NAV_GROUP_ROLES all 4 groups, RoleSwitcher with 15 options + super-admin toggle, mockContext.ts default fix | (none) | enums.ts (+SharePointAdmin), permissions.ts (+role entry with ...Object.values(PERMISSIONS), +NAV_GROUP_ROLES all 4 groups), users.json (+Alex Torres id:25), permissionTemplates.json (+id:9 full ADMIN), securityGroupMappings.json (+id:9), MockDataService.ts (+_isDevSuperAdmin, +setDevSuperAdminMode, getCurrentUser super-admin branch, resolveUserPermissions super-admin short-circuit + SharePoint Admin in roleToGroupMap), RoleSwitcher.tsx (RoleValue union type, 15 options, red pill for super-admin), dev/index.tsx (RoleValue type, super-admin detection), dev/mockContext.ts (default→ExecutiveLeadership) |
 
+| 21 | Preconstruction Navigation Cleanup — Reduced Preconstruction nav from 10→7 items, moved Accounting Queue to new Accounting nav group, moved Go/No-Go Tracker from EstimatingDashboard tab to PipelinePage tab. PipelinePage now 2-tab (Pipeline + Go/No-Go Tracker). EstimatingDashboard now 3-tab (removed Go/No-Go). | (none) | NavigationSidebar.tsx (removed 3 items, added Accounting group, updated Go/No-Go path), permissions.ts (+Accounting NAV_GROUP_ROLES), EstimatingDashboard.tsx (removed tab 3, gonogoRegionFilter, gonogoLeads, gonogoColumns, GoNoGoDecision import), PipelinePage.tsx (2-tab rewrite: Pipeline + Go/No-Go Tracker with region filter, sort, export), App.tsx (+/preconstruction/pipeline/gonogo route, /preconstruction/gonogo→PipelinePage), constants.ts (+PRECON_PIPELINE_GONOGO) |
+| 22 | Lead-to-Site Workflow Enhancement — ScorecardStatus 8→10 values (BDDraft, AwaitingDirectorReview, DirectorReturnedForRevision, AwaitingCommitteeScoring, CommitteeReturnedForRevision, Rejected, NoGo, Go, Locked, Unlocked), IAssignmentMapping model for admin-configurable Director/Estimator assignments per Region/Sector, BD Leads folder creation on lead create, GoNoGoScorecard Save/Submit + Director review/reject + Committee Go/NoGo/Return + archive flow, PipelinePage Go/No-Go Tracker Pending/Archive sub-tabs with advanced filtering, JobNumberRequestForm optional lead association, AdminPanel Assignment Mappings CRUD, 7 new NotificationService event handlers | IAssignmentMapping.ts, assignmentMappings.json, useAssignmentMappings.ts | enums.ts (ScorecardStatus 10 values, +3 AuditAction, +7 NotificationEvent, +1 EntityType), IGoNoGoScorecard.ts (+unlockedSections, +isArchived, +archivedDate, +archivedBy), models/index.ts, IDataService.ts (+8 methods, 200 total), MockDataService.ts (+8 implementations, updated scorecard workflow methods for new statuses), SharePointDataService.ts (+8 stubs), columnMappings.ts (+Assignment_Mappings), NotificationService.ts (+7 event handlers), constants.ts (+ASSIGNMENT_MAPPINGS, +BD_LEADS constants), permissions.ts (+gonogo:review, +admin:assignments:manage), hooks/index.ts (+1 export), useGoNoGo.ts (new statuses, +canReviewDirector, +canReviewCommittee, +canArchive, +rejectScorecard, +archiveScorecard), GoNoGoScorecard.tsx (Save/Submit, Director/Committee action bars, reject/archive dialogs), PipelinePage.tsx (Pending/Archive sub-tabs, advanced filters, scorecard-lead join), LeadFormPage.tsx (+BD Leads folder creation), JobNumberRequestForm.tsx (+optional lead association, manual fields), EstimatingDashboard.tsx (+Request New Project Number button), AdminPanel.tsx (+Assignment Mappings section), scorecards.json (updated to new ScorecardStatus values) |
+
 ### Known Stubs / Placeholders
 
-- **SharePointDataService**: 143 of 192 methods are stubs (return empty/null/throw). All Phase 7+ project-level list operations are stubbed.
+- **SharePointDataService**: 151 of 200 methods are stubs (return empty/null/throw). All Phase 7+ project-level list operations are stubbed.
 - **HubNavigationService**: SharePointHubNavigationService is a stub (all 3 methods throw).
 - **Column Mappings**: `columnMappings.ts` has mappings for all lists but SP service stubs don't use them yet.
 - **Offline Support**: `OfflineQueueService.ts` exists but feature flag `OfflineSupport` is disabled.
@@ -1411,7 +1437,7 @@ TRANSITION = { fast: '150ms ease', normal: '250ms ease', slow: '350ms ease' }
 ### SharePointDataService Status
 
 - **Implemented (49)**: Leads CRUD, Go/No-Go CRUD, Estimating CRUD, Roles/Flags CRUD, Audit log/read, Provisioning read, Phase 6 workflow (team, deliverables, interview, contract, turnover, closeout, loss autopsy), Buyout/Commitment/Compliance, Active Projects Portfolio, AppContextConfig, hub site URL read
-- **Stubbed (143)**: All startup checklist, all matrices, all marketing records, all risk/cost/quality/safety/schedule, all superintendent plan, all lessons learned, all PMP, all monthly review, all estimating kickoff, all job number requests, all workflow definitions, all turnover agenda, all permission templates, all security group mappings, all project team assignments, all sector definitions, resolveUserPermissions, getAccessibleProjects, getEnvironmentConfig, promoteTemplates, reference data, re-key, sync, promote, getCurrentUser, meetings, notifications, provisioning triggers, hub site URL write, action inbox (SP)
+- **Stubbed (151)**: All startup checklist, all matrices, all marketing records, all risk/cost/quality/safety/schedule, all superintendent plan, all lessons learned, all PMP, all monthly review, all estimating kickoff, all job number requests, all workflow definitions, all turnover agenda, all permission templates, all security group mappings, all project team assignments, all sector definitions, all assignment mappings, all BD Leads folder operations, resolveUserPermissions, getAccessibleProjects, getEnvironmentConfig, promoteTemplates, reference data, re-key, sync, promote, getCurrentUser, meetings, notifications, provisioning triggers, hub site URL write, action inbox (SP)
 
 ---
 
@@ -1467,6 +1493,10 @@ TRANSITION = { fast: '150ms ease', normal: '250ms ease', slow: '350ms ease' }
 
 25. **Dev Super-Admin is NOT a real role** — `DEV_SUPER_ADMIN` is a dev-only sentinel string used by the RoleSwitcher. It is NOT a `RoleName` enum value and must never be sent to production or used in `ROLE_PERMISSIONS`. It grants the union of ALL permissions from every role purely for local testing convenience. The `_isDevSuperAdmin` flag on `MockDataService` is not part of `IDataService`.
 
+26. **ScorecardStatus enum was replaced in Phase 22** — The old 8-value enum (Draft, Submitted, ReturnedForRevision, InCommitteeReview, PendingDecision, Decided, Locked, Unlocked) was replaced with a new 10-value enum. Old → New mapping: Draft→BDDraft, Submitted→AwaitingDirectorReview, ReturnedForRevision→DirectorReturnedForRevision, InCommitteeReview→AwaitingCommitteeScoring. `PendingDecision` and `Decided` were removed (replaced by `Go`, `NoGo`, `Rejected`). New values: `CommitteeReturnedForRevision`, `Rejected`, `NoGo`, `Go`. Any code referencing old enum members will fail at compile time.
+
+27. **Assignment mapping resolution uses 4-tier fallback** — `resolveAssignee(region, sector, type)` in `useAssignmentMappings` resolves via: exact region+sector → exact region+"All Sectors" → "All Regions"+exact sector → "All Regions"+"All Sectors". Always add a fallback "All Regions" + "All Sectors" mapping as a catch-all.
+
 ---
 
 ## Audit Log
@@ -1486,3 +1516,5 @@ TRANSITION = { fast: '150ms ease', normal: '250ms ease', slow: '350ms ease' }
 | 2026-02-10 | §2, §6, §7, §12, §13, §15 | Phase 19D: Flexible Sectors + Identity. New ISectorDefinition model + sectorDefinitions.json (12 entries). 3 new service methods (192 total): getSectorDefinitions, createSectorDefinition, updateSectorDefinition. Sector enum deprecated. ICurrentUser gains identityType. AdminPanel Sectors tab (8th tab). LeadFormPage, PipelinePage, ConditionBuilder use dynamic sectors when PermissionEngine enabled. New hook useSectorDefinitions. |
 | 2026-02-10 | §10, §16 | Permission Engine activation polish: RoleSwitcher enterprise hierarchy labels (seniority-ordered, persona names). IDS (OpEx Manager) gains permission:templates:manage, permission:project_team:manage, permission:project_team:view. toolPermissionMap admin_panel ADMIN level gains permission engine keys. MockDataService default role → ExecutiveLeadership. resolveUserPermissions console.log for debugging. |
 | 2026-02-10 | §6, §10, §12, §15, §16 | Phase 20: SharePoint Admin Role + Dev Super-Admin. Added 14th RoleName (SharePointAdmin). ROLE_PERMISSIONS entry with `...Object.values(PERMISSIONS)` (ALL permissions). NAV_GROUP_ROLES: SharePoint Admin added to all 4 groups (Marketing, Preconstruction, Operations, Admin). Dev Super-Admin mode: union of ALL role permissions (dev-only, not a real role). MockDataService: +_isDevSuperAdmin +setDevSuperAdminMode, getCurrentUser super-admin branch, resolveUserPermissions super-admin short-circuit + 'SharePoint Admin' in roleToGroupMap. RoleSwitcher widened to RoleValue union type with 15 options + red pill badge. dev/index.tsx super-admin detection. mockContext.ts default fixed to ExecutiveLeadership. users.json +Alex Torres (id:25). permissionTemplates.json +id:9 (SharePoint Admin, all 23 tools at ADMIN). securityGroupMappings.json +id:9. |
+| 2026-02-10 | §3, §8, §9, §10, §13, §15 | Phase 21: Preconstruction Navigation Cleanup. Preconstruction nav 10→7 items (removed Precon Tracker, Estimate Log, Accounting Queue). New Accounting nav group (Acct Mgr, Exec, Dept Dir, SP Admin). Go/No-Go Tracker moved from EstimatingDashboard tab 3 to PipelinePage tab 1. PipelinePage now 2-tab (Pipeline + Go/No-Go Tracker). EstimatingDashboard now 3-tab. /preconstruction/gonogo backward compat→PipelinePage. Route count 48→49. NAV_GROUP_ROLES +Accounting. ROUTES +PRECON_PIPELINE_GONOGO. |
+| 2026-02-11 | §2, §6, §7, §10, §12, §13, §15, §16 | Phase 22: Lead-to-Site Workflow Enhancement. ScorecardStatus replaced (8→10 values: BDDraft, AwaitingDirectorReview, DirectorReturnedForRevision, AwaitingCommitteeScoring, CommitteeReturnedForRevision, Rejected, NoGo, Go, Locked, Unlocked). New IAssignmentMapping model + assignmentMappings.json (4 entries) + useAssignmentMappings hook. 8 new IDataService methods (200 total): createBdLeadFolder, checkFolderExists, createFolder, renameFolder, getAssignmentMappings, createAssignmentMapping, updateAssignmentMapping, deleteAssignmentMapping. +3 AuditAction (ScorecardArchived, LeadFolderCreated, AssignmentMappingUpdated), +7 NotificationEvent (ScorecardSubmittedToDirector, ScorecardReturnedByDirector, ScorecardRejectedByDirector, ScorecardAdvancedToCommittee, ScorecardApprovedGo, ScorecardDecidedNoGo, EstimatingCoordinatorNotifiedGo), +1 EntityType (AssignmentMapping). +2 permissions (gonogo:review, admin:assignments:manage). GoNoGoScorecard.tsx rewritten with Save/Submit, Director review/reject, Committee Go/NoGo/Return, archive flow. PipelinePage.tsx Go/No-Go Tracker with Pending/Archive sub-tabs + advanced filters. LeadFormPage.tsx +BD Leads folder creation. JobNumberRequestForm.tsx +optional lead association. EstimatingDashboard.tsx +Request New Project Number button. AdminPanel.tsx +Assignment Mappings CRUD. scorecards.json updated to new status values. Added pitfalls #26-#27. |

--- a/src/webparts/hbcProjectControls/components/App.tsx
+++ b/src/webparts/hbcProjectControls/components/App.tsx
@@ -84,8 +84,9 @@ const AppRoutes: React.FC = () => (
 
     {/* Preconstruction */}
     <Route path="/preconstruction" element={<EstimatingDashboard />} />
-    <Route path="/preconstruction/gonogo" element={<GoNoGoTracker />} />
     <Route path="/preconstruction/pipeline" element={<PipelinePage />} />
+    <Route path="/preconstruction/pipeline/gonogo" element={<PipelinePage />} />
+    <Route path="/preconstruction/gonogo" element={<PipelinePage />} />
     <Route path="/preconstruction/precon-tracker" element={<EstimatingDashboard />} />
     <Route path="/preconstruction/estimate-log" element={<EstimatingDashboard />} />
     <Route path="/preconstruction/kickoff-list" element={

--- a/src/webparts/hbcProjectControls/components/hooks/index.ts
+++ b/src/webparts/hbcProjectControls/components/hooks/index.ts
@@ -33,3 +33,4 @@ export { useTabFromUrl } from './useTabFromUrl';
 export { useKeyboardShortcut } from './useKeyboardShortcut';
 export { usePermissionEngine } from './usePermissionEngine';
 export { useSectorDefinitions } from './useSectorDefinitions';
+export { useAssignmentMappings } from './useAssignmentMappings';

--- a/src/webparts/hbcProjectControls/components/hooks/useAssignmentMappings.ts
+++ b/src/webparts/hbcProjectControls/components/hooks/useAssignmentMappings.ts
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import { useAppContext } from '../contexts/AppContext';
+import { IAssignmentMapping, AssignmentType } from '../../models';
+
+interface IUseAssignmentMappingsResult {
+  mappings: IAssignmentMapping[];
+  isLoading: boolean;
+  error: string | null;
+  fetchMappings: () => Promise<void>;
+  createMapping: (data: Partial<IAssignmentMapping>) => Promise<IAssignmentMapping>;
+  updateMapping: (id: number, data: Partial<IAssignmentMapping>) => Promise<IAssignmentMapping>;
+  deleteMapping: (id: number) => Promise<void>;
+  resolveAssignee: (region: string, sector: string, type: AssignmentType) => IAssignmentMapping | null;
+}
+
+export function useAssignmentMappings(): IUseAssignmentMappingsResult {
+  const { dataService } = useAppContext();
+  const [mappings, setMappings] = React.useState<IAssignmentMapping[]>([]);
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const fetchMappings = React.useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const items = await dataService.getAssignmentMappings();
+      setMappings(items);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch assignment mappings');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [dataService]);
+
+  const createMapping = React.useCallback(async (data: Partial<IAssignmentMapping>) => {
+    const created = await dataService.createAssignmentMapping(data);
+    setMappings(prev => [...prev, created]);
+    return created;
+  }, [dataService]);
+
+  const updateMapping = React.useCallback(async (id: number, data: Partial<IAssignmentMapping>) => {
+    const updated = await dataService.updateAssignmentMapping(id, data);
+    setMappings(prev => prev.map(m => m.id === id ? updated : m));
+    return updated;
+  }, [dataService]);
+
+  const deleteMapping = React.useCallback(async (id: number) => {
+    await dataService.deleteAssignmentMapping(id);
+    setMappings(prev => prev.filter(m => m.id !== id));
+  }, [dataService]);
+
+  /**
+   * Resolve the best-matching assignee for a given region, sector, and type.
+   * Priority: exact region+sector → exact region+"All Sectors" → "All Regions"+exact sector → "All Regions"+"All Sectors"
+   */
+  const resolveAssignee = React.useCallback((region: string, sector: string, type: AssignmentType): IAssignmentMapping | null => {
+    const candidates = mappings.filter(m => m.assignmentType === type);
+
+    // Priority 1: Exact region + exact sector
+    const exact = candidates.find(m => m.region === region && m.sector === sector);
+    if (exact) return exact;
+
+    // Priority 2: Exact region + "All Sectors"
+    const regionOnly = candidates.find(m => m.region === region && m.sector === 'All Sectors');
+    if (regionOnly) return regionOnly;
+
+    // Priority 3: "All Regions" + exact sector
+    const sectorOnly = candidates.find(m => m.region === 'All Regions' && m.sector === sector);
+    if (sectorOnly) return sectorOnly;
+
+    // Priority 4: "All Regions" + "All Sectors" (fallback)
+    const fallback = candidates.find(m => m.region === 'All Regions' && m.sector === 'All Sectors');
+    return fallback || null;
+  }, [mappings]);
+
+  return {
+    mappings, isLoading, error,
+    fetchMappings, createMapping, updateMapping, deleteMapping,
+    resolveAssignee,
+  };
+}

--- a/src/webparts/hbcProjectControls/components/hooks/useGoNoGo.ts
+++ b/src/webparts/hbcProjectControls/components/hooks/useGoNoGo.ts
@@ -35,6 +35,9 @@ interface IUseGoNoGoResult {
   computeRecommendation: (committeeTotal: number) => IRecommendation;
   // Decision
   recordDecision: (scorecardId: number, decision: GoNoGoDecision, conditions?: string) => Promise<IGoNoGoScorecard>;
+  // Reject / Archive (Phase 22)
+  rejectScorecard: (scorecardId: number, reason: string) => Promise<IGoNoGoScorecard>;
+  archiveScorecard: (scorecardId: number) => Promise<IGoNoGoScorecard>;
   // Unlock
   canUnlock: boolean;
   unlockScorecard: (scorecardId: number, reason: string) => Promise<IGoNoGoScorecard>;
@@ -49,8 +52,11 @@ interface IUseGoNoGoResult {
   canEdit: boolean;
   canSubmit: boolean;
   canReview: boolean;
+  canReviewDirector: boolean;
+  canReviewCommittee: boolean;
   canEnterCommitteeScores: boolean;
   canDecide: boolean;
+  canArchive: boolean;
 }
 
 export function useGoNoGo(): IUseGoNoGoResult {
@@ -133,6 +139,22 @@ export function useGoNoGo(): IUseGoNoGoResult {
     return updated;
   }, [dataService, currentUser]);
 
+  // --- Phase 22: Reject / Archive ---
+
+  const rejectScorecard = React.useCallback(async (scorecardId: number, reason: string) => {
+    const updated = await dataService.rejectScorecard(scorecardId, reason);
+    setScorecards(prev => prev.map(s => s.id === scorecardId ? updated : s));
+    setActiveScorecard(updated);
+    return updated;
+  }, [dataService]);
+
+  const archiveScorecard = React.useCallback(async (scorecardId: number) => {
+    const updated = await dataService.archiveScorecard(scorecardId, currentUser?.displayName ?? 'Unknown');
+    setScorecards(prev => prev.map(s => s.id === scorecardId ? updated : s));
+    setActiveScorecard(updated);
+    return updated;
+  }, [dataService, currentUser]);
+
   const unlockScorecard = React.useCallback(async (scorecardId: number, reason: string) => {
     const updated = await dataService.unlockScorecard(scorecardId, reason);
     setScorecards(prev => prev.map(s => s.id === scorecardId ? updated : s));
@@ -162,8 +184,9 @@ export function useGoNoGo(): IUseGoNoGoResult {
     if (!activeScorecard) return true; // New scorecard
     const status = activeScorecard.scorecardStatus;
     return (
-      status === ScorecardStatus.Draft ||
-      status === ScorecardStatus.ReturnedForRevision ||
+      status === ScorecardStatus.BDDraft ||
+      status === ScorecardStatus.DirectorReturnedForRevision ||
+      status === ScorecardStatus.CommitteeReturnedForRevision ||
       status === ScorecardStatus.Unlocked
     );
   }, [activeScorecard]);
@@ -172,7 +195,10 @@ export function useGoNoGo(): IUseGoNoGoResult {
     if (!activeScorecard) return false;
     const status = activeScorecard.scorecardStatus;
     return (
-      (status === ScorecardStatus.Draft || status === ScorecardStatus.ReturnedForRevision || status === ScorecardStatus.Unlocked) &&
+      (status === ScorecardStatus.BDDraft ||
+       status === ScorecardStatus.DirectorReturnedForRevision ||
+       status === ScorecardStatus.CommitteeReturnedForRevision ||
+       status === ScorecardStatus.Unlocked) &&
       hasPermission(PERMISSIONS.GONOGO_SUBMIT)
     );
   }, [activeScorecard, hasPermission]);
@@ -181,21 +207,37 @@ export function useGoNoGo(): IUseGoNoGoResult {
     || currentUser?.roles?.includes(RoleName.DepartmentDirector)
     || false;
 
-  const canReview = React.useMemo(() => {
+  const canReviewDirector = React.useMemo(() => {
     if (!activeScorecard) return false;
-    if (activeScorecard.scorecardStatus !== ScorecardStatus.Submitted) return false;
+    if (activeScorecard.scorecardStatus !== ScorecardStatus.AwaitingDirectorReview) return false;
     if (isDirectorOrExec) return true;
+    if (hasPermission(PERMISSIONS.GONOGO_REVIEW)) return true;
     const activeCycle = activeScorecard.approvalCycles?.find(c => c.status === 'Active');
     if (!activeCycle) return false;
     const pendingStep = activeCycle.steps?.find(s => s.status === 'Pending');
     if (!pendingStep) return false;
     const userEmail = currentUser?.email?.toLowerCase();
-    return pendingStep.assigneeEmail?.toLowerCase() === userEmail || hasPermission(PERMISSIONS.GONOGO_DECIDE);
+    return pendingStep.assigneeEmail?.toLowerCase() === userEmail;
+  }, [activeScorecard, currentUser, hasPermission, isDirectorOrExec]);
+
+  // Alias for backward compatibility
+  const canReview = canReviewDirector;
+
+  const canReviewCommittee = React.useMemo(() => {
+    if (!activeScorecard) return false;
+    if (activeScorecard.scorecardStatus !== ScorecardStatus.AwaitingCommitteeScoring) return false;
+    if (isDirectorOrExec) return true;
+    if (hasPermission(PERMISSIONS.GONOGO_SCORE_COMMITTEE)) return true;
+    const userEmail = currentUser?.email?.toLowerCase();
+    const isInCycle = activeScorecard.approvalCycles?.some(cycle =>
+      cycle.steps?.some(step => step.assigneeEmail?.toLowerCase() === userEmail)
+    ) || false;
+    return isInCycle;
   }, [activeScorecard, currentUser, hasPermission, isDirectorOrExec]);
 
   const canEnterCommitteeScores = React.useMemo(() => {
     if (!activeScorecard) return false;
-    if (activeScorecard.scorecardStatus !== ScorecardStatus.InCommitteeReview) return false;
+    if (activeScorecard.scorecardStatus !== ScorecardStatus.AwaitingCommitteeScoring) return false;
     if (isDirectorOrExec) return true;
     const userEmail = currentUser?.email?.toLowerCase();
     const isInCycle = activeScorecard.approvalCycles?.some(cycle =>
@@ -206,7 +248,7 @@ export function useGoNoGo(): IUseGoNoGoResult {
 
   const canDecide = React.useMemo(() => {
     if (!activeScorecard) return false;
-    if (activeScorecard.scorecardStatus !== ScorecardStatus.PendingDecision) return false;
+    if (activeScorecard.scorecardStatus !== ScorecardStatus.AwaitingCommitteeScoring) return false;
     if (isDirectorOrExec) return true;
     const userEmail = currentUser?.email?.toLowerCase();
     const isInCycle = activeScorecard.approvalCycles?.some(cycle =>
@@ -228,9 +270,20 @@ export function useGoNoGo(): IUseGoNoGoResult {
     return isInApprovalChain || isDirectorOrExecLocal;
   }, [activeScorecard, currentUser]);
 
+  const canArchive = React.useMemo(() => {
+    if (!activeScorecard) return false;
+    if (activeScorecard.isArchived) return false;
+    const status = activeScorecard.scorecardStatus;
+    return (
+      status === ScorecardStatus.Rejected ||
+      status === ScorecardStatus.NoGo ||
+      status === ScorecardStatus.Go
+    );
+  }, [activeScorecard]);
+
   const recommendedDecision = React.useMemo(() => {
     if (!activeScorecard?.TotalScore_Cmte) return null;
-    if (activeScorecard.scorecardStatus !== ScorecardStatus.PendingDecision) return null;
+    if (activeScorecard.scorecardStatus !== ScorecardStatus.AwaitingCommitteeScoring) return null;
     return getRecommendedDecision(activeScorecard.TotalScore_Cmte);
   }, [activeScorecard]);
 
@@ -243,11 +296,14 @@ export function useGoNoGo(): IUseGoNoGoResult {
     enterCommitteeScores, recommendedDecision, computeRecommendation,
     // Decision
     recordDecision,
+    // Reject / Archive
+    rejectScorecard, archiveScorecard,
     // Unlock
     canUnlock, unlockScorecard, relockScorecard,
     // Version
     versions, currentVersion, loadVersions,
     // Computed status
-    scorecardStatus, isLocked, canEdit, canSubmit, canReview, canEnterCommitteeScores, canDecide,
+    scorecardStatus, isLocked, canEdit, canSubmit, canReview, canReviewDirector, canReviewCommittee,
+    canEnterCommitteeScores, canDecide, canArchive,
   };
 }

--- a/src/webparts/hbcProjectControls/components/layouts/NavigationSidebar.tsx
+++ b/src/webparts/hbcProjectControls/components/layouts/NavigationSidebar.tsx
@@ -34,14 +34,11 @@ const NAV_STRUCTURE: INavGroupDef[] = [
     items: [
       { label: 'Estimating Dashboard', path: '/preconstruction' },
       { label: 'Pipeline', path: '/preconstruction/pipeline' },
-      { label: 'Go/No-Go Tracker', path: '/preconstruction/gonogo' },
-      { label: 'Precon Tracker', path: '/preconstruction/precon-tracker' },
-      { label: 'Estimate Log', path: '/preconstruction/estimate-log' },
+      { label: 'Go/No-Go Tracker', path: '/preconstruction/pipeline/gonogo' },
       { label: 'Kick-Off Checklists', path: '/preconstruction/kickoff-list', permission: PERMISSIONS.KICKOFF_VIEW },
       { label: 'Post-Bid Autopsies', path: '/preconstruction/autopsy-list', permission: PERMISSIONS.AUTOPSY_VIEW },
       { label: 'New Lead', path: '/lead/new', permission: PERMISSIONS.LEAD_CREATE },
       { label: 'Job Number Request', path: '/job-request', permission: PERMISSIONS.JOB_NUMBER_REQUEST_CREATE },
-      { label: 'Accounting Queue', path: '/accounting-queue', permission: PERMISSIONS.ACCOUNTING_QUEUE_VIEW },
     ],
   },
   {
@@ -81,6 +78,13 @@ const NAV_STRUCTURE: INavGroupDef[] = [
           { label: 'Lessons Learned', path: '/operations/lessons-learned', requiresProject: true },
         ],
       },
+    ],
+  },
+  {
+    label: 'Accounting',
+    groupKey: 'Accounting',
+    items: [
+      { label: 'Accounting Queue', path: '/accounting-queue', permission: PERMISSIONS.ACCOUNTING_QUEUE_VIEW },
     ],
   },
   {

--- a/src/webparts/hbcProjectControls/components/pages/hub/LeadFormPage.tsx
+++ b/src/webparts/hbcProjectControls/components/pages/hub/LeadFormPage.tsx
@@ -73,6 +73,21 @@ export const LeadFormPage: React.FC = () => {
         leadId: newLead.id,
         clientName: newLead.ClientName,
       }).catch(console.error);
+      // Fire-and-forget BD Leads folder creation
+      try {
+        const originatorName = currentUser?.displayName || 'Unknown';
+        await dataService.createBdLeadFolder(newLead.Title, originatorName);
+        dataService.logAudit({
+          Action: AuditAction.LeadFolderCreated,
+          EntityType: EntityType.Lead,
+          EntityId: String(newLead.id),
+          User: originatorName,
+          Details: `BD Leads folder created for "${newLead.Title}"`,
+        }).catch(console.error);
+      } catch (folderErr) {
+        console.error('Failed to create BD Leads folder:', folderErr);
+        addToast('Lead created but folder creation failed', 'error');
+      }
       addToast('Lead created successfully', 'success');
       navigate('/');
     } catch (err) {

--- a/src/webparts/hbcProjectControls/components/pages/hub/PipelinePage.tsx
+++ b/src/webparts/hbcProjectControls/components/pages/hub/PipelinePage.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Button, Select } from '@fluentui/react-components';
 import { useLeads } from '../../hooks/useLeads';
+import { useGoNoGo } from '../../hooks/useGoNoGo';
 import { useAppContext } from '../../contexts/AppContext';
 import { useResponsive } from '../../hooks/useResponsive';
 import { PageHeader } from '../../shared/PageHeader';
@@ -10,25 +11,43 @@ import { buildBreadcrumbs } from '../../../utils/breadcrumbs';
 import { KPICard } from '../../shared/KPICard';
 import { PipelineChart } from '../../shared/PipelineChart';
 import { StageBadge } from '../../shared/StageBadge';
+import { StatusBadge } from '../../shared/StatusBadge';
 import { SkeletonLoader } from '../../shared/SkeletonLoader';
 import { DataTable, IDataTableColumn } from '../../shared/DataTable';
 import { ExportButtons } from '../../shared/ExportButtons';
 import { FeatureGate } from '../../guards/FeatureGate';
-import { ILead, Stage, Region, Sector, Division, AwardStatus, GoNoGoDecision } from '../../../models';
+import { ILead, IGoNoGoScorecard, Stage, Region, Sector, Division, GoNoGoDecision, ScorecardStatus } from '../../../models';
 import { useSectorDefinitions } from '../../hooks/useSectorDefinitions';
 import { HBC_COLORS } from '../../../theme/tokens';
 import { formatCurrencyCompact, formatDate, formatPercent } from '../../../utils/formatters';
 import { isActiveStage } from '../../../utils/stageEngine';
 import { PERMISSIONS } from '../../../utils/permissions';
 
+const TAB_PATHS = ['/preconstruction/pipeline', '/preconstruction/pipeline/gonogo'];
+const TAB_LABELS = ['Pipeline', 'Go/No-Go Tracker'];
+
+function pathToTab(pathname: string): number {
+  // Support both /preconstruction/pipeline/gonogo and legacy /preconstruction/gonogo
+  if (pathname === '/preconstruction/pipeline/gonogo' || pathname === '/preconstruction/gonogo') return 1;
+  if (pathname === '/preconstruction/pipeline') return 0;
+  return 0;
+}
+
+const CheckIcon: React.FC = () => (
+  <span style={{ color: HBC_COLORS.success, fontSize: '16px', fontWeight: 700 }}>&#10003;</span>
+);
+
 export const PipelinePage: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const activeTab = pathToTab(location.pathname);
   const breadcrumbs = buildBreadcrumbs(location.pathname);
   const { hasPermission, isFeatureEnabled } = useAppContext();
   const { activeSectors } = useSectorDefinitions();
   const { leads, totalCount, isLoading, fetchLeads } = useLeads();
   const { isMobile } = useResponsive();
+
+  // Pipeline tab state
   const [chartMode, setChartMode] = React.useState<'count' | 'value'>('count');
   const [stageFilter, setStageFilter] = React.useState<string>('all');
   const [regionFilter, setRegionFilter] = React.useState<string>('all');
@@ -37,9 +56,20 @@ export const PipelinePage: React.FC = () => {
   const [sortField, setSortField] = React.useState<string>('Title');
   const [sortAsc, setSortAsc] = React.useState(true);
 
+  // Go/No-Go tab state
+  const { scorecards, fetchScorecards } = useGoNoGo();
+  const [gonogoSubTab, setGonogoSubTab] = React.useState<'pending' | 'archive'>('pending');
+  const [gonogoRegionFilter, setGonogoRegionFilter] = React.useState('All');
+  const [gonogoSectorFilter, setGonogoSectorFilter] = React.useState('All');
+  const [gonogoBdRepFilter, setGonogoBdRepFilter] = React.useState('All');
+  const [gonogoStatusFilter, setGonogoStatusFilter] = React.useState<string[]>([]);
+  const [gonogoSortField, setGonogoSortField] = React.useState<string>('');
+  const [gonogoSortAsc, setGonogoSortAsc] = React.useState(true);
+
   React.useEffect(() => {
     fetchLeads().catch(console.error);
-  }, [fetchLeads]);
+    fetchScorecards().catch(console.error);
+  }, [fetchLeads, fetchScorecards]);
 
   const handleSort = (field: string): void => {
     if (sortField === field) {
@@ -50,6 +80,15 @@ export const PipelinePage: React.FC = () => {
     }
   };
 
+  const handleGonogoSort = React.useCallback((field: string) => {
+    setGonogoSortField(prev => {
+      if (prev === field) { setGonogoSortAsc(a => !a); return field; }
+      setGonogoSortAsc(true);
+      return field;
+    });
+  }, []);
+
+  // --- Pipeline tab data ---
   const filteredLeads = React.useMemo(() => {
     let result = [...leads];
     if (stageFilter !== 'all') result = result.filter(l => l.Stage === stageFilter);
@@ -147,7 +186,6 @@ export const PipelinePage: React.FC = () => {
     },
   ], []);
 
-  // KPI calculations
   const kpis = React.useMemo(() => {
     const active = filteredLeads.filter(l => isActiveStage(l.Stage));
     const totalPipelineValue = active.reduce((sum, l) => sum + (l.ProjectValue || 0), 0);
@@ -173,72 +211,337 @@ export const PipelinePage: React.FC = () => {
     setDivisionFilter('all');
   };
 
+  // --- Go/No-Go tab data ---
+
+  // Status color mapping for StatusBadge
+  const STATUS_COLORS: Record<string, { color: string; bg: string }> = {
+    [ScorecardStatus.BDDraft]: { color: HBC_COLORS.gray700, bg: HBC_COLORS.gray100 },
+    [ScorecardStatus.AwaitingDirectorReview]: { color: '#92400E', bg: '#FEF3C7' },
+    [ScorecardStatus.DirectorReturnedForRevision]: { color: '#9A3412', bg: '#FFEDD5' },
+    [ScorecardStatus.AwaitingCommitteeScoring]: { color: '#1E40AF', bg: HBC_COLORS.infoLight },
+    [ScorecardStatus.CommitteeReturnedForRevision]: { color: '#9A3412', bg: '#FFEDD5' },
+    [ScorecardStatus.Rejected]: { color: '#991B1B', bg: HBC_COLORS.errorLight },
+    [ScorecardStatus.NoGo]: { color: '#991B1B', bg: HBC_COLORS.errorLight },
+    [ScorecardStatus.Go]: { color: '#065F46', bg: HBC_COLORS.successLight },
+    [ScorecardStatus.Locked]: { color: HBC_COLORS.gray600, bg: HBC_COLORS.gray200 },
+    [ScorecardStatus.Unlocked]: { color: '#92400E', bg: '#FEF3C7' },
+  };
+
+  const PENDING_STATUSES = [
+    ScorecardStatus.BDDraft,
+    ScorecardStatus.AwaitingDirectorReview,
+    ScorecardStatus.DirectorReturnedForRevision,
+    ScorecardStatus.AwaitingCommitteeScoring,
+    ScorecardStatus.CommitteeReturnedForRevision,
+    ScorecardStatus.Unlocked,
+  ];
+
+  const ARCHIVE_STATUSES = [
+    ScorecardStatus.Go,
+    ScorecardStatus.NoGo,
+    ScorecardStatus.Rejected,
+    ScorecardStatus.Locked,
+  ];
+
+  // Join scorecards with leads
+  interface IScorecardRow {
+    scorecard: IGoNoGoScorecard;
+    lead: ILead | null;
+    id: number;
+    title: string;
+    originator: string;
+    region: string;
+    sector: string;
+    status: string;
+    lastDate: string;
+  }
+
+  const allScorecardRows = React.useMemo((): IScorecardRow[] => {
+    const leadMap = new Map(leads.map(l => [l.id, l]));
+    return scorecards.map(sc => {
+      const lead = leadMap.get(sc.LeadID) || null;
+      return {
+        scorecard: sc,
+        lead,
+        id: sc.id,
+        title: lead?.Title || `Lead #${sc.LeadID}`,
+        originator: lead?.Originator || '',
+        region: lead?.Region || '',
+        sector: lead?.Sector || '',
+        status: sc.scorecardStatus || ScorecardStatus.BDDraft,
+        lastDate: sc.DecisionDate || sc.finalDecisionDate || sc.committeeScoresEnteredDate || '',
+      };
+    });
+  }, [scorecards, leads]);
+
+  const pendingRows = React.useMemo(
+    () => allScorecardRows.filter(r => !r.scorecard.isArchived && PENDING_STATUSES.includes(r.status as ScorecardStatus)),
+    [allScorecardRows]
+  );
+
+  const archiveRows = React.useMemo(
+    () => allScorecardRows.filter(r =>
+      r.scorecard.isArchived || ARCHIVE_STATUSES.includes(r.status as ScorecardStatus)
+    ),
+    [allScorecardRows]
+  );
+
+  const activeGonogoRows = gonogoSubTab === 'pending' ? pendingRows : archiveRows;
+
+  // Filter options from data
+  const gonogoRegions = React.useMemo(() => {
+    const r = new Set<string>();
+    activeGonogoRows.forEach(row => { if (row.region) r.add(row.region); });
+    return ['All', ...Array.from(r).sort()];
+  }, [activeGonogoRows]);
+
+  const gonogoSectors = React.useMemo(() => {
+    const s = new Set<string>();
+    activeGonogoRows.forEach(row => { if (row.sector) s.add(row.sector); });
+    return ['All', ...Array.from(s).sort()];
+  }, [activeGonogoRows]);
+
+  const gonogoBdReps = React.useMemo(() => {
+    const b = new Set<string>();
+    activeGonogoRows.forEach(row => { if (row.originator) b.add(row.originator); });
+    return ['All', ...Array.from(b).sort()];
+  }, [activeGonogoRows]);
+
+  const gonogoStatusOptions = gonogoSubTab === 'pending' ? PENDING_STATUSES : ARCHIVE_STATUSES;
+
+  // Apply filters
+  const gonogoFiltered = React.useMemo(() => {
+    let result = activeGonogoRows;
+    if (gonogoRegionFilter !== 'All') result = result.filter(r => r.region === gonogoRegionFilter);
+    if (gonogoSectorFilter !== 'All') result = result.filter(r => r.sector === gonogoSectorFilter);
+    if (gonogoBdRepFilter !== 'All') result = result.filter(r => r.originator === gonogoBdRepFilter);
+    if (gonogoStatusFilter.length > 0) result = result.filter(r => gonogoStatusFilter.includes(r.status));
+    return result;
+  }, [activeGonogoRows, gonogoRegionFilter, gonogoSectorFilter, gonogoBdRepFilter, gonogoStatusFilter]);
+
+  const gonogoColumns: IDataTableColumn<IScorecardRow>[] = React.useMemo(() => [
+    { key: 'title', header: 'Lead Title', sortable: true,
+      render: (r) => (
+        <span
+          style={{ fontWeight: 500, color: HBC_COLORS.navy, cursor: 'pointer', textDecoration: 'underline' }}
+          onClick={(e) => { e.stopPropagation(); if (r.lead) navigate(`/lead/${r.lead.id}/gonogo`); }}
+        >
+          {r.title}
+        </span>
+      ),
+    },
+    { key: 'originator', header: 'BD Rep', sortable: true, render: (r) => r.originator, hideOnMobile: true },
+    { key: 'region', header: 'Region', sortable: true, width: '120px', render: (r) => r.region },
+    { key: 'sector', header: 'Sector', sortable: true, width: '120px', render: (r) => r.sector, hideOnMobile: true },
+    { key: 'status', header: 'Status', sortable: true, width: '180px',
+      render: (r) => {
+        const colors = STATUS_COLORS[r.status] || { color: HBC_COLORS.gray700, bg: HBC_COLORS.gray100 };
+        return <StatusBadge label={r.status} color={colors.color} backgroundColor={colors.bg} />;
+      },
+    },
+    { key: 'lastDate', header: 'Date', sortable: true, width: '100px',
+      render: (r) => r.lastDate ? formatDate(r.lastDate) : '-' },
+    { key: 'scores', header: 'Score (Orig / Cmte)', width: '140px',
+      render: (r) => <span>{r.scorecard.TotalScore_Orig ?? '-'} / {r.scorecard.TotalScore_Cmte ?? '-'}</span> },
+  ], [navigate]);
+
+  const gonogoExportData = React.useMemo(() =>
+    gonogoFiltered.map(r => ({
+      'Lead Title': r.title,
+      'BD Rep': r.originator,
+      Region: r.region,
+      Sector: r.sector,
+      Status: r.status,
+      Date: r.lastDate,
+      'Originator Score': r.scorecard.TotalScore_Orig ?? '',
+      'Committee Score': r.scorecard.TotalScore_Cmte ?? '',
+    })),
+  [gonogoFiltered]);
+
+  const hasGonogoFilters = gonogoRegionFilter !== 'All' || gonogoSectorFilter !== 'All' || gonogoBdRepFilter !== 'All' || gonogoStatusFilter.length > 0;
+
+  const clearGonogoFilters = (): void => {
+    setGonogoRegionFilter('All');
+    setGonogoSectorFilter('All');
+    setGonogoBdRepFilter('All');
+    setGonogoStatusFilter([]);
+  };
+
   if (isLoading) return <SkeletonLoader variant="table" rows={8} columns={5} />;
+
+  const tabStyle = (idx: number): React.CSSProperties => ({
+    padding: '10px 20px', cursor: 'pointer', fontSize: '14px', fontWeight: activeTab === idx ? 600 : 400,
+    color: activeTab === idx ? HBC_COLORS.navy : HBC_COLORS.gray500,
+    borderBottom: activeTab === idx ? `3px solid ${HBC_COLORS.orange}` : '3px solid transparent',
+    transition: 'all 0.2s',
+  });
+
+  const selectStyle: React.CSSProperties = {
+    padding: '6px 10px', borderRadius: '6px', border: `1px solid ${HBC_COLORS.gray200}`,
+    fontSize: '13px', backgroundColor: '#fff', color: HBC_COLORS.gray800,
+  };
 
   return (
     <FeatureGate featureName="PipelineDashboard">
       <div id="pipeline-view">
         <PageHeader
-          title="Project Pipeline"
-          subtitle={`${totalCount} leads across all stages`}
+          title={activeTab === 0 ? 'Project Pipeline' : 'Go/No-Go Tracker'}
+          subtitle={activeTab === 0
+            ? `${totalCount} leads across all stages`
+            : `${gonogoFiltered.length} scorecards — ${gonogoSubTab === 'pending' ? 'In Progress' : 'Completed / Archived'}`}
           breadcrumb={<Breadcrumb items={breadcrumbs} />}
           actions={
-            <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
-              <ExportButtons data={exportData} filename="pipeline-export" title="Project Pipeline" />
-              {hasPermission(PERMISSIONS.LEAD_CREATE) && (
-                <Button appearance="primary" onClick={() => navigate('/lead/new')}>New Lead</Button>
-              )}
-            </div>
+            activeTab === 0 ? (
+              <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
+                <ExportButtons data={exportData} filename="pipeline-export" title="Project Pipeline" />
+                {hasPermission(PERMISSIONS.LEAD_CREATE) && (
+                  <Button appearance="primary" onClick={() => navigate('/lead/new')}>New Lead</Button>
+                )}
+              </div>
+            ) : (
+              <ExportButtons
+                data={gonogoExportData}
+                pdfElementId="pipeline-view"
+                filename="gonogo-tracker"
+                title="Go/No-Go Tracker"
+              />
+            )
           }
         />
-        {/* KPI Cards */}
-        <div style={{ display: 'grid', gridTemplateColumns: isMobile ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)', gap: '16px', marginBottom: '24px' }}>
-          <KPICard title="Total Pipeline Value" value={formatCurrencyCompact(kpis.totalPipelineValue)} subtitle={`${kpis.activePursuits} active projects`} />
-          <KPICard title="Active Pursuits" value={kpis.activePursuits} subtitle="Across all active stages" />
-          <KPICard title="Leads This Month" value={kpis.thisMonth} subtitle={new Date().toLocaleDateString('en-US', { month: 'long', year: 'numeric' })} />
-          <KPICard title="Win Rate" value={formatPercent(kpis.winRate)} subtitle="GO / (GO + Archived)" />
+
+        {/* Tabs */}
+        <div style={{ display: 'flex', borderBottom: `1px solid ${HBC_COLORS.gray200}`, marginBottom: '20px' }}>
+          {TAB_LABELS.map((label, idx) => (
+            <div
+              key={idx}
+              style={tabStyle(idx)}
+              onClick={() => navigate(TAB_PATHS[idx])}
+            >
+              {label}
+            </div>
+          ))}
         </div>
 
-        {/* Pipeline Chart */}
-        <div style={{ marginBottom: '24px' }}>
-          <PipelineChart leads={filteredLeads} mode={chartMode} />
-        </div>
+        {/* Tab 0: Pipeline */}
+        {activeTab === 0 && (
+          <>
+            {/* KPI Cards */}
+            <div style={{ display: 'grid', gridTemplateColumns: isMobile ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)', gap: '16px', marginBottom: '24px' }}>
+              <KPICard title="Total Pipeline Value" value={formatCurrencyCompact(kpis.totalPipelineValue)} subtitle={`${kpis.activePursuits} active projects`} />
+              <KPICard title="Active Pursuits" value={kpis.activePursuits} subtitle="Across all active stages" />
+              <KPICard title="Leads This Month" value={kpis.thisMonth} subtitle={new Date().toLocaleDateString('en-US', { month: 'long', year: 'numeric' })} />
+              <KPICard title="Win Rate" value={formatPercent(kpis.winRate)} subtitle="GO / (GO + Archived)" />
+            </div>
 
-        <div style={{ display: 'flex', gap: '8px', marginBottom: '16px', flexWrap: 'wrap', alignItems: 'center' }}>
-          <Select value={stageFilter} onChange={(_, data) => setStageFilter(data.value)} style={{ minWidth: '160px' }}>
-            <option value="all">All Stages</option>
-            {Object.values(Stage).map(s => <option key={s} value={s}>{s}</option>)}
-          </Select>
-          <Select value={regionFilter} onChange={(_, data) => setRegionFilter(data.value)} style={{ minWidth: '160px' }}>
-            <option value="all">All Regions</option>
-            {Object.values(Region).map(r => <option key={r} value={r}>{r}</option>)}
-          </Select>
-          <Select value={sectorFilter} onChange={(_, data) => setSectorFilter(data.value)} style={{ minWidth: '160px' }}>
-            <option value="all">All Sectors</option>
-            {(isFeatureEnabled('PermissionEngine') && activeSectors.length > 0
-              ? activeSectors.map(s => <option key={s.label} value={s.label}>{s.label}</option>)
-              : Object.values(Sector).map(s => <option key={s} value={s}>{s}</option>)
-            )}
-          </Select>
-          <Select value={divisionFilter} onChange={(_, data) => setDivisionFilter(data.value)} style={{ minWidth: '160px' }}>
-            <option value="all">All Divisions</option>
-            {Object.values(Division).map(d => <option key={d} value={d}>{d}</option>)}
-          </Select>
-          {hasActiveFilters && (
-            <Button size="small" appearance="subtle" onClick={clearFilters}>Clear Filters</Button>
-          )}
-        </div>
-        <DataTable<ILead>
-          columns={columns}
-          items={filteredLeads}
-          keyExtractor={(lead) => lead.id}
-          onRowClick={(lead) => navigate(`/lead/${lead.id}`)}
-          sortField={sortField}
-          sortAsc={sortAsc}
-          onSort={handleSort}
-          emptyTitle="No leads found"
-          emptyDescription={hasActiveFilters ? 'Try adjusting your filters' : 'No leads in the pipeline'}
-        />
+            {/* Pipeline Chart */}
+            <div style={{ marginBottom: '24px' }}>
+              <PipelineChart leads={filteredLeads} mode={chartMode} />
+            </div>
+
+            <div style={{ display: 'flex', gap: '8px', marginBottom: '16px', flexWrap: 'wrap', alignItems: 'center' }}>
+              <Select value={stageFilter} onChange={(_, data) => setStageFilter(data.value)} style={{ minWidth: '160px' }}>
+                <option value="all">All Stages</option>
+                {Object.values(Stage).map(s => <option key={s} value={s}>{s}</option>)}
+              </Select>
+              <Select value={regionFilter} onChange={(_, data) => setRegionFilter(data.value)} style={{ minWidth: '160px' }}>
+                <option value="all">All Regions</option>
+                {Object.values(Region).map(r => <option key={r} value={r}>{r}</option>)}
+              </Select>
+              <Select value={sectorFilter} onChange={(_, data) => setSectorFilter(data.value)} style={{ minWidth: '160px' }}>
+                <option value="all">All Sectors</option>
+                {(isFeatureEnabled('PermissionEngine') && activeSectors.length > 0
+                  ? activeSectors.map(s => <option key={s.label} value={s.label}>{s.label}</option>)
+                  : Object.values(Sector).map(s => <option key={s} value={s}>{s}</option>)
+                )}
+              </Select>
+              <Select value={divisionFilter} onChange={(_, data) => setDivisionFilter(data.value)} style={{ minWidth: '160px' }}>
+                <option value="all">All Divisions</option>
+                {Object.values(Division).map(d => <option key={d} value={d}>{d}</option>)}
+              </Select>
+              {hasActiveFilters && (
+                <Button size="small" appearance="subtle" onClick={clearFilters}>Clear Filters</Button>
+              )}
+            </div>
+            <DataTable<ILead>
+              columns={columns}
+              items={filteredLeads}
+              keyExtractor={(lead) => lead.id}
+              onRowClick={(lead) => navigate(`/lead/${lead.id}`)}
+              sortField={sortField}
+              sortAsc={sortAsc}
+              onSort={handleSort}
+              emptyTitle="No leads found"
+              emptyDescription={hasActiveFilters ? 'Try adjusting your filters' : 'No leads in the pipeline'}
+            />
+          </>
+        )}
+
+        {/* Tab 1: Go/No-Go Tracker */}
+        {activeTab === 1 && (
+          <>
+            {/* Pending / Archive sub-tabs */}
+            <div style={{ display: 'flex', gap: '0', marginBottom: '16px' }}>
+              {(['pending', 'archive'] as const).map(sub => (
+                <button
+                  key={sub}
+                  onClick={() => { setGonogoSubTab(sub); clearGonogoFilters(); }}
+                  style={{
+                    padding: '8px 20px',
+                    fontSize: '13px',
+                    fontWeight: gonogoSubTab === sub ? 600 : 400,
+                    color: gonogoSubTab === sub ? '#fff' : HBC_COLORS.gray600,
+                    backgroundColor: gonogoSubTab === sub ? HBC_COLORS.navy : HBC_COLORS.gray100,
+                    border: `1px solid ${gonogoSubTab === sub ? HBC_COLORS.navy : HBC_COLORS.gray200}`,
+                    borderRadius: sub === 'pending' ? '6px 0 0 6px' : '0 6px 6px 0',
+                    cursor: 'pointer',
+                    transition: 'all 0.15s',
+                  }}
+                >
+                  {sub === 'pending' ? `Pending (${pendingRows.length})` : `Archive (${archiveRows.length})`}
+                </button>
+              ))}
+            </div>
+
+            {/* Advanced Filters */}
+            <div style={{
+              display: 'flex', gap: '8px', marginBottom: '16px', flexWrap: 'wrap', alignItems: 'center',
+              padding: '12px', backgroundColor: HBC_COLORS.gray50, borderRadius: '8px', border: `1px solid ${HBC_COLORS.gray200}`,
+            }}>
+              <select style={selectStyle} value={gonogoRegionFilter} onChange={e => setGonogoRegionFilter(e.target.value)}>
+                {gonogoRegions.map(r => <option key={r} value={r}>{r === 'All' ? 'All Regions' : r}</option>)}
+              </select>
+              <select style={selectStyle} value={gonogoSectorFilter} onChange={e => setGonogoSectorFilter(e.target.value)}>
+                {gonogoSectors.map(s => <option key={s} value={s}>{s === 'All' ? 'All Sectors' : s}</option>)}
+              </select>
+              <select style={selectStyle} value={gonogoBdRepFilter} onChange={e => setGonogoBdRepFilter(e.target.value)}>
+                {gonogoBdReps.map(b => <option key={b} value={b}>{b === 'All' ? 'All BD Reps' : b}</option>)}
+              </select>
+              <select
+                style={selectStyle}
+                value={gonogoStatusFilter.length === 1 ? gonogoStatusFilter[0] : ''}
+                onChange={e => setGonogoStatusFilter(e.target.value ? [e.target.value] : [])}
+              >
+                <option value="">All Statuses</option>
+                {gonogoStatusOptions.map(s => <option key={s} value={s}>{s}</option>)}
+              </select>
+              {hasGonogoFilters && (
+                <Button size="small" appearance="subtle" onClick={clearGonogoFilters}>Clear</Button>
+              )}
+            </div>
+
+            <DataTable<IScorecardRow>
+              columns={gonogoColumns}
+              items={gonogoFiltered}
+              keyExtractor={r => r.id}
+              sortField={gonogoSortField}
+              sortAsc={gonogoSortAsc}
+              onSort={handleGonogoSort}
+              onRowClick={(r) => { if (r.lead) navigate(`/lead/${r.lead.id}/gonogo`); }}
+              emptyTitle={gonogoSubTab === 'pending' ? 'No pending scorecards' : 'No archived scorecards'}
+              emptyDescription={hasGonogoFilters ? 'Try adjusting your filters' : (gonogoSubTab === 'pending' ? 'Scorecards in progress will appear here' : 'Completed scorecards will appear here')}
+            />
+          </>
+        )}
       </div>
     </FeatureGate>
   );

--- a/src/webparts/hbcProjectControls/components/pages/precon/EstimatingDashboard.tsx
+++ b/src/webparts/hbcProjectControls/components/pages/precon/EstimatingDashboard.tsx
@@ -12,7 +12,7 @@ import { KPICard } from '../../shared/KPICard';
 import { StatusBadge } from '../../shared/StatusBadge';
 import { DataTable, IDataTableColumn } from '../../shared/DataTable';
 import { SkeletonLoader } from '../../shared/SkeletonLoader';
-import { IEstimatingTracker, ILead, GoNoGoDecision, AwardStatus, AuditAction, EntityType, RoleName } from '../../../models';
+import { IEstimatingTracker, ILead, AwardStatus, AuditAction, EntityType, RoleName } from '../../../models';
 import { HBC_COLORS } from '../../../theme/tokens';
 import {
   formatCurrency,
@@ -24,8 +24,8 @@ import {
 } from '../../../utils/formatters';
 import { exportService } from '../../../services/ExportService';
 
-const TAB_PATHS = ['/preconstruction', '/preconstruction/precon-tracker', '/preconstruction/estimate-log', '/preconstruction/gonogo'];
-const TAB_LABELS = ['Current Pursuits', 'Current Preconstruction', 'Estimate Log', 'Go/No-Go Tracker'];
+const TAB_PATHS = ['/preconstruction', '/preconstruction/precon-tracker', '/preconstruction/estimate-log'];
+const TAB_LABELS = ['Current Pursuits', 'Current Preconstruction', 'Estimate Log'];
 
 function pathToTab(pathname: string): number {
   const idx = TAB_PATHS.indexOf(pathname);
@@ -52,7 +52,6 @@ export const EstimatingDashboard: React.FC = () => {
   const [yearFilter, setYearFilter] = usePersistedState('estimating-year', 'All');
   const [estimatorFilter, setEstimatorFilter] = usePersistedState('estimating-estimator', 'All');
   const [regionFilter, setRegionFilter] = usePersistedState('estimating-region', 'All');
-  const [gonogoRegionFilter, setGonogoRegionFilter] = usePersistedState('estimating-gonogo-region', 'All');
   const [sortField, setSortField] = React.useState<string>('');
   const [sortAsc, setSortAsc] = React.useState(true);
 
@@ -122,22 +121,6 @@ export const EstimatingDashboard: React.FC = () => {
     () => filteredRecords.filter(r => !!r.SubmittedDate),
     [filteredRecords]
   );
-
-  // Go/No-Go leads
-  const gonogoLeads = React.useMemo(() => {
-    return leads.filter(l => l.GoNoGoDecision || l.GoNoGoScore_Originator).filter(l => {
-      if (gonogoRegionFilter !== 'All' && l.Region !== gonogoRegionFilter) return false;
-      return true;
-    });
-  }, [leads, gonogoRegionFilter]);
-
-  const gonogoRegions = React.useMemo(() => {
-    const r = new Set<string>();
-    leads.filter(l => l.GoNoGoDecision || l.GoNoGoScore_Originator).forEach(l => {
-      if (l.Region) r.add(l.Region);
-    });
-    return ['All', ...Array.from(r).sort()];
-  }, [leads]);
 
   // KPI calculations
   const kpis = React.useMemo(() => {
@@ -338,23 +321,6 @@ export const EstimatingDashboard: React.FC = () => {
     )},
   ], []);
 
-  // Go/No-Go Tracker columns
-  const gonogoColumns: IDataTableColumn<ILead>[] = React.useMemo(() => [
-    { key: 'GoNoGoDecisionDate', header: 'Date', sortable: true, width: '100px', render: (l) => formatDate(l.GoNoGoDecisionDate || l.DateOfEvaluation) },
-    { key: 'Title', header: 'Project', sortable: true, render: (l) => (
-      <span style={{ fontWeight: 500, color: HBC_COLORS.navy }}>{l.Title}</span>
-    )},
-    { key: 'Region', header: 'Region', sortable: true, width: '120px', render: (l) => l.Region },
-    { key: 'Approved', header: 'Approved', width: '70px', render: (l) => l.GoNoGoDecision === GoNoGoDecision.Go ? <CheckIcon /> : null },
-    { key: 'Declined', header: 'Declined', width: '70px', render: (l) => l.GoNoGoDecision === GoNoGoDecision.NoGo ? <CheckIcon /> : null },
-    { key: 'Conditional', header: 'Conditional', width: '70px', render: (l) => l.GoNoGoDecision === GoNoGoDecision.ConditionalGo ? <CheckIcon /> : null },
-    { key: 'Score', header: 'Score (Orig / Cmte)', width: '140px', render: (l) => {
-      const orig = l.GoNoGoScore_Originator;
-      const cmte = l.GoNoGoScore_Committee;
-      return <span>{orig ?? '-'} / {cmte ?? '-'}</span>;
-    }},
-  ], []);
-
   // Precon fee totals
   const preconTotals = React.useMemo(() => ({
     preconFee: preconEngagements.reduce((s, r) => s + (r.PreconFee || 0), 0),
@@ -497,16 +463,28 @@ export const EstimatingDashboard: React.FC = () => {
         subtitle="Current pursuit, preconstruction, and estimate tracking"
         breadcrumb={<Breadcrumb items={breadcrumbs} />}
         actions={
-          <button
-            onClick={() => { handleExport().catch(console.error); }}
-            style={{
-              padding: '8px 16px', borderRadius: '6px', border: `1px solid ${HBC_COLORS.gray200}`,
-              backgroundColor: '#fff', fontSize: '13px', cursor: 'pointer', fontWeight: 500,
-              color: HBC_COLORS.navy,
-            }}
-          >
-            Export to Excel
-          </button>
+          <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+            <button
+              onClick={() => navigate('/job-request')}
+              style={{
+                padding: '8px 16px', borderRadius: '6px', border: 'none',
+                backgroundColor: HBC_COLORS.orange, fontSize: '13px', cursor: 'pointer', fontWeight: 600,
+                color: '#fff',
+              }}
+            >
+              Request New Project Number
+            </button>
+            <button
+              onClick={() => { handleExport().catch(console.error); }}
+              style={{
+                padding: '8px 16px', borderRadius: '6px', border: `1px solid ${HBC_COLORS.gray200}`,
+                backgroundColor: '#fff', fontSize: '13px', cursor: 'pointer', fontWeight: 500,
+                color: HBC_COLORS.navy,
+              }}
+            >
+              Export to Excel
+            </button>
+          </div>
         }
       />
 
@@ -519,28 +497,26 @@ export const EstimatingDashboard: React.FC = () => {
       </div>
 
       {/* Cross-Tab Filters */}
-      {activeTab < 3 && (
-        <div style={{ display: 'flex', gap: '12px', marginBottom: '16px', flexWrap: 'wrap', alignItems: 'center' }}>
-          <label style={{ fontSize: '13px', color: HBC_COLORS.gray500 }}>
-            Year:
-            <select style={{ ...selectStyle, marginLeft: '6px' }} value={yearFilter} onChange={e => setYearFilter(e.target.value)}>
-              {filterOptions.years.map(y => <option key={y} value={y}>{y}</option>)}
-            </select>
-          </label>
-          <label style={{ fontSize: '13px', color: HBC_COLORS.gray500 }}>
-            Lead Estimator:
-            <select style={{ ...selectStyle, marginLeft: '6px' }} value={estimatorFilter} onChange={e => setEstimatorFilter(e.target.value)}>
-              {filterOptions.estimators.map(e => <option key={e} value={e}>{e}</option>)}
-            </select>
-          </label>
-          <label style={{ fontSize: '13px', color: HBC_COLORS.gray500 }}>
-            Region:
-            <select style={{ ...selectStyle, marginLeft: '6px' }} value={regionFilter} onChange={e => setRegionFilter(e.target.value)}>
-              {filterOptions.regions.map(r => <option key={r} value={r}>{r}</option>)}
-            </select>
-          </label>
-        </div>
-      )}
+      <div style={{ display: 'flex', gap: '12px', marginBottom: '16px', flexWrap: 'wrap', alignItems: 'center' }}>
+        <label style={{ fontSize: '13px', color: HBC_COLORS.gray500 }}>
+          Year:
+          <select style={{ ...selectStyle, marginLeft: '6px' }} value={yearFilter} onChange={e => setYearFilter(e.target.value)}>
+            {filterOptions.years.map(y => <option key={y} value={y}>{y}</option>)}
+          </select>
+        </label>
+        <label style={{ fontSize: '13px', color: HBC_COLORS.gray500 }}>
+          Lead Estimator:
+          <select style={{ ...selectStyle, marginLeft: '6px' }} value={estimatorFilter} onChange={e => setEstimatorFilter(e.target.value)}>
+            {filterOptions.estimators.map(e => <option key={e} value={e}>{e}</option>)}
+          </select>
+        </label>
+        <label style={{ fontSize: '13px', color: HBC_COLORS.gray500 }}>
+          Region:
+          <select style={{ ...selectStyle, marginLeft: '6px' }} value={regionFilter} onChange={e => setRegionFilter(e.target.value)}>
+            {filterOptions.regions.map(r => <option key={r} value={r}>{r}</option>)}
+          </select>
+        </label>
+      </div>
 
       {/* Tabs */}
       <div style={{ display: 'flex', borderBottom: `1px solid ${HBC_COLORS.gray200}`, marginBottom: '20px' }}>
@@ -622,28 +598,6 @@ export const EstimatingDashboard: React.FC = () => {
         </>
       )}
 
-      {activeTab === 3 && (
-        <>
-          <div style={{ display: 'flex', gap: '12px', marginBottom: '16px', alignItems: 'center' }}>
-            <label style={{ fontSize: '13px', color: HBC_COLORS.gray500 }}>
-              Region:
-              <select style={{ ...selectStyle, marginLeft: '6px' }} value={gonogoRegionFilter} onChange={e => setGonogoRegionFilter(e.target.value)}>
-                {gonogoRegions.map(r => <option key={r} value={r}>{r}</option>)}
-              </select>
-            </label>
-          </div>
-          <DataTable<ILead>
-            columns={gonogoColumns}
-            items={gonogoLeads}
-            keyExtractor={l => l.id}
-            sortField={sortField}
-            sortAsc={sortAsc}
-            onSort={handleSort}
-            emptyTitle="No Go/No-Go records"
-            emptyDescription="Leads with Go/No-Go activity appear here"
-          />
-        </>
-      )}
     </div>
     </RoleGate>
   );

--- a/src/webparts/hbcProjectControls/mock/assignmentMappings.json
+++ b/src/webparts/hbcProjectControls/mock/assignmentMappings.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": 1,
+    "region": "Miami",
+    "sector": "All Sectors",
+    "assignmentType": "Director",
+    "assignee": {
+      "userId": "dpark",
+      "displayName": "David Park",
+      "email": "dpark@hedrickbrothers.com"
+    }
+  },
+  {
+    "id": 2,
+    "region": "West Palm Beach",
+    "sector": "All Sectors",
+    "assignmentType": "Director",
+    "assignee": {
+      "userId": "dpark",
+      "displayName": "David Park",
+      "email": "dpark@hedrickbrothers.com"
+    }
+  },
+  {
+    "id": 3,
+    "region": "Miami",
+    "sector": "All Sectors",
+    "assignmentType": "Estimator",
+    "assignee": {
+      "userId": "jthompson",
+      "displayName": "Jason Thompson",
+      "email": "jthompson@hedrickbrothers.com"
+    }
+  },
+  {
+    "id": 4,
+    "region": "All Regions",
+    "sector": "All Sectors",
+    "assignmentType": "Director",
+    "assignee": {
+      "userId": "dpark",
+      "displayName": "David Park",
+      "email": "dpark@hedrickbrothers.com"
+    }
+  }
+]

--- a/src/webparts/hbcProjectControls/mock/scorecards.json
+++ b/src/webparts/hbcProjectControls/mock/scorecards.json
@@ -164,7 +164,7 @@
       "CommitteeComments": "Committee scores entered. Awaiting scheduling of committee meeting for final review and scoring.",
       "ScoredBy_Orig": "kfoster@hedrickbrothers.com",
       "ScoredBy_Cmte": ["dpark@hedrickbrothers.com"],
-      "scorecardStatus": "In Committee Review",
+      "scorecardStatus": "Awaiting Committee Scoring",
       "currentApprovalStep": 2,
       "committeeScoresEnteredBy": "dpark@hedrickbrothers.com",
       "committeeScoresEnteredDate": "2026-02-07",
@@ -339,7 +339,7 @@
       "OriginatorComments": "K-12 public school market is steady work. Seminole County has multiple projects coming from bond referendum. This could lead to program management relationship.",
       "CommitteeComments": "",
       "ScoredBy_Orig": "jrodriguez@hedrickbrothers.com",
-      "scorecardStatus": "Submitted",
+      "scorecardStatus": "Awaiting Director Review",
       "currentApprovalStep": 1,
       "currentVersion": 1,
       "isLocked": false
@@ -414,7 +414,7 @@
       "TotalScore_Orig": 73,
       "OriginatorComments": "Major healthcare opportunity in growing Orlando market. Orlando Health is one of the largest health systems in FL. HKS is a trusted AE partner for us. Strong pursuit potential.",
       "ScoredBy_Orig": "jrodriguez@hedrickbrothers.com",
-      "scorecardStatus": "Draft",
+      "scorecardStatus": "BD Draft",
       "currentVersion": 1,
       "isLocked": false
     }

--- a/src/webparts/hbcProjectControls/models/IAssignmentMapping.ts
+++ b/src/webparts/hbcProjectControls/models/IAssignmentMapping.ts
@@ -1,0 +1,9 @@
+export type AssignmentType = 'Estimator' | 'Director';
+
+export interface IAssignmentMapping {
+  id: number;
+  region: string;          // Region value or 'All Regions'
+  sector: string;          // Sector label or 'All Sectors'
+  assignmentType: AssignmentType;
+  assignee: { userId: string; displayName: string; email: string };
+}

--- a/src/webparts/hbcProjectControls/models/IGoNoGoScorecard.ts
+++ b/src/webparts/hbcProjectControls/models/IGoNoGoScorecard.ts
@@ -81,6 +81,11 @@ export interface IGoNoGoScorecard {
   unlockedBy?: string;
   unlockedDate?: string;
   unlockReason?: string;
+  // Phase 22 — partial unlock + archive
+  unlockedSections?: string[];  // e.g., ['bd'] for partial unlock of BD fields only
+  isArchived?: boolean;
+  archivedDate?: string;
+  archivedBy?: string;
 }
 
 // IPersonAssignment is defined in IWorkflowDefinition.ts and re-exported from barrel

--- a/src/webparts/hbcProjectControls/models/enums.ts
+++ b/src/webparts/hbcProjectControls/models/enums.ts
@@ -63,14 +63,16 @@ export enum GoNoGoDecision {
 }
 
 export enum ScorecardStatus {
-  Draft = 'Draft',
-  Submitted = 'Submitted',
-  ReturnedForRevision = 'Returned for Revision',
-  InCommitteeReview = 'In Committee Review',
-  PendingDecision = 'Pending Decision',
-  Decided = 'Decided',
+  BDDraft = 'BD Draft',
+  AwaitingDirectorReview = 'Awaiting Director Review',
+  DirectorReturnedForRevision = 'Director Returned for Revision',
+  AwaitingCommitteeScoring = 'Awaiting Committee Scoring',
+  CommitteeReturnedForRevision = 'Committee Returned for Revision',
+  Rejected = 'Rejected',
+  NoGo = 'No Go',
+  Go = 'Go',
   Locked = 'Locked',
-  Unlocked = 'Unlocked'
+  Unlocked = 'Unlocked',
 }
 
 export enum WinLossDecision {
@@ -182,7 +184,10 @@ export enum AuditAction {
   ProjectTeamRemoved = 'Permission.ProjectTeamRemoved',
   ProjectTeamOverridden = 'Permission.ProjectTeamOverridden',
   SecurityGroupMappingChanged = 'Permission.SecurityGroupMappingChanged',
-  PermissionResolved = 'Permission.Resolved'
+  PermissionResolved = 'Permission.Resolved',
+  ScorecardArchived = 'Scorecard.Archived',
+  LeadFolderCreated = 'Lead.FolderCreated',
+  AssignmentMappingUpdated = 'Assignment.MappingUpdated',
 }
 
 export enum EntityType {
@@ -206,7 +211,8 @@ export enum EntityType {
   WorkflowDefinition = 'WorkflowDefinition',
   TurnoverAgenda = 'TurnoverAgenda',
   PermissionTemplate = 'PermissionTemplate',
-  ProjectTeamAssignment = 'ProjectTeamAssignment'
+  ProjectTeamAssignment = 'ProjectTeamAssignment',
+  AssignmentMapping = 'AssignmentMapping',
 }
 
 export enum DeliverableStatus {
@@ -322,7 +328,14 @@ export enum NotificationEvent {
   ScorecardReturnedForRevision = 'ScorecardReturnedForRevision',
   ScorecardCommitteeScoresFinalized = 'ScorecardCommitteeScoresFinalized',
   ScorecardDecisionRecorded = 'ScorecardDecisionRecorded',
-  ScorecardUnlockedForEditing = 'ScorecardUnlockedForEditing'
+  ScorecardUnlockedForEditing = 'ScorecardUnlockedForEditing',
+  ScorecardSubmittedToDirector = 'ScorecardSubmittedToDirector',
+  ScorecardReturnedByDirector = 'ScorecardReturnedByDirector',
+  ScorecardRejectedByDirector = 'ScorecardRejectedByDirector',
+  ScorecardAdvancedToCommittee = 'ScorecardAdvancedToCommittee',
+  ScorecardApprovedGo = 'ScorecardApprovedGo',
+  ScorecardDecidedNoGo = 'ScorecardDecidedNoGo',
+  EstimatingCoordinatorNotifiedGo = 'EstimatingCoordinatorNotifiedGo',
 }
 
 export enum TurnoverStatus {

--- a/src/webparts/hbcProjectControls/models/index.ts
+++ b/src/webparts/hbcProjectControls/models/index.ts
@@ -41,3 +41,4 @@ export * from './IActionInbox';
 export * from './IPermissionTemplate';
 export * from './IEnvironmentConfig';
 export * from './ISectorDefinition';
+export * from './IAssignmentMapping';

--- a/src/webparts/hbcProjectControls/services/IDataService.ts
+++ b/src/webparts/hbcProjectControls/services/IDataService.ts
@@ -40,6 +40,7 @@ import { IActionInboxItem } from '../models/IActionInbox';
 import { IPermissionTemplate, ISecurityGroupMapping, IProjectTeamAssignment, IResolvedPermissions } from '../models/IPermissionTemplate';
 import { IEnvironmentConfig, EnvironmentTier } from '../models/IEnvironmentConfig';
 import { ISectorDefinition } from '../models/ISectorDefinition';
+import { IAssignmentMapping } from '../models/IAssignmentMapping';
 import { GoNoGoDecision, Stage, WorkflowKey } from '../models/enums';
 
 export interface IListQueryOptions {
@@ -363,6 +364,22 @@ export interface IDataService {
   getSectorDefinitions(): Promise<ISectorDefinition[]>;
   createSectorDefinition(data: Partial<ISectorDefinition>): Promise<ISectorDefinition>;
   updateSectorDefinition(id: number, data: Partial<ISectorDefinition>): Promise<ISectorDefinition>;
+
+  // BD Leads Document Library (folder operations)
+  createBdLeadFolder(leadTitle: string, originatorName: string): Promise<void>;
+  checkFolderExists(path: string): Promise<boolean>;
+  createFolder(path: string): Promise<void>;
+  renameFolder(oldPath: string, newPath: string): Promise<void>;
+
+  // Assignment Mappings
+  getAssignmentMappings(): Promise<IAssignmentMapping[]>;
+  createAssignmentMapping(data: Partial<IAssignmentMapping>): Promise<IAssignmentMapping>;
+  updateAssignmentMapping(id: number, data: Partial<IAssignmentMapping>): Promise<IAssignmentMapping>;
+  deleteAssignmentMapping(id: number): Promise<void>;
+
+  // Scorecard archive (Phase 22)
+  rejectScorecard(scorecardId: number, reason: string): Promise<IGoNoGoScorecard>;
+  archiveScorecard(scorecardId: number, archivedBy: string): Promise<IGoNoGoScorecard>;
 }
 
 export interface IActiveProjectsQueryOptions extends IListQueryOptions {

--- a/src/webparts/hbcProjectControls/services/NotificationService.ts
+++ b/src/webparts/hbcProjectControls/services/NotificationService.ts
@@ -27,6 +27,9 @@ export interface INotificationContext {
   committeeTotal?: number;
   unlockedBy?: string;
   reason?: string;
+  comment?: string;
+  conditions?: string;
+  decisionDate?: string;
 }
 
 interface INotificationTemplate {
@@ -232,6 +235,62 @@ function buildTemplate(
         body: `The Go/No-Go scorecard for "${ctx.leadTitle}" has been unlocked for editing by ${ctx.unlockedBy ?? 'Unknown'}.${ctx.reason ? ` Reason: ${ctx.reason}` : ''}`,
         type: NotificationType.Both,
         recipientRoles: ['BD Representative', 'Executive Leadership', 'Department Director'],
+      };
+
+    case NotificationEvent.ScorecardSubmittedToDirector:
+      return {
+        subject: `Go/No-Go Scorecard Submitted for Review: ${ctx.leadTitle ?? 'Untitled'}`,
+        body: `A Go/No-Go scorecard for "${ctx.leadTitle}" has been submitted for Director review by ${ctx.submittedBy ?? 'Unknown'}. Please review and approve, return, or reject.`,
+        type: NotificationType.Both,
+        recipientRoles: ['Department Director', 'Executive Leadership'],
+      };
+
+    case NotificationEvent.ScorecardReturnedByDirector:
+      return {
+        subject: `Go/No-Go Scorecard Returned for Revision: ${ctx.leadTitle ?? 'Untitled'}`,
+        body: `The Go/No-Go scorecard for "${ctx.leadTitle}" has been returned for revision by the Director.${ctx.comment ? ` Comment: ${ctx.comment}` : ''}`,
+        type: NotificationType.Both,
+        recipientRoles: ['BD Representative'],
+      };
+
+    case NotificationEvent.ScorecardRejectedByDirector:
+      return {
+        subject: `Go/No-Go Scorecard Rejected: ${ctx.leadTitle ?? 'Untitled'}`,
+        body: `The Go/No-Go scorecard for "${ctx.leadTitle}" has been rejected by the Director.${ctx.reason ? ` Reason: ${ctx.reason}` : ''} The BD Rep may revise and resubmit or archive.`,
+        type: NotificationType.Both,
+        recipientRoles: ['BD Representative', 'Executive Leadership'],
+      };
+
+    case NotificationEvent.ScorecardAdvancedToCommittee:
+      return {
+        subject: `Go/No-Go Scorecard Advanced to Committee: ${ctx.leadTitle ?? 'Untitled'}`,
+        body: `The Go/No-Go scorecard for "${ctx.leadTitle}" has been approved by the Director and advanced to the Go/No-Go Committee for scoring and decision.`,
+        type: NotificationType.Both,
+        recipientRoles: ['Executive Leadership', 'Department Director', 'Estimating Coordinator'],
+      };
+
+    case NotificationEvent.ScorecardApprovedGo:
+      return {
+        subject: `GO Decision: ${ctx.leadTitle ?? 'Untitled'}`,
+        body: `The Go/No-Go Committee has approved "${ctx.leadTitle}" as GO.${ctx.conditions ? ` Conditions: ${ctx.conditions}` : ''} The Estimating Coordinator has been notified to proceed.`,
+        type: NotificationType.Both,
+        recipientRoles: ['BD Representative', 'Executive Leadership', 'Department Director', 'Estimating Coordinator'],
+      };
+
+    case NotificationEvent.ScorecardDecidedNoGo:
+      return {
+        subject: `NO GO Decision: ${ctx.leadTitle ?? 'Untitled'}`,
+        body: `The Go/No-Go Committee has decided NO GO for "${ctx.leadTitle}". The scorecard has been archived.`,
+        type: NotificationType.Both,
+        recipientRoles: ['BD Representative', 'Executive Leadership', 'Department Director'],
+      };
+
+    case NotificationEvent.EstimatingCoordinatorNotifiedGo:
+      return {
+        subject: `New GO Project Ready for Estimating: ${ctx.leadTitle ?? 'Untitled'}`,
+        body: `"${ctx.leadTitle}" has received a GO decision on ${ctx.decisionDate ?? 'today'}. Please begin the estimating kickoff process.`,
+        type: NotificationType.Both,
+        recipientRoles: ['Estimating Coordinator'],
       };
 
     default:

--- a/src/webparts/hbcProjectControls/services/SharePointDataService.ts
+++ b/src/webparts/hbcProjectControls/services/SharePointDataService.ts
@@ -1337,4 +1337,20 @@ export class SharePointDataService implements IDataService {
   async getSectorDefinitions(): Promise<import('../models/ISectorDefinition').ISectorDefinition[]> { return []; }
   async createSectorDefinition(_data: Partial<import('../models/ISectorDefinition').ISectorDefinition>): Promise<import('../models/ISectorDefinition').ISectorDefinition> { throw new Error('Not implemented'); }
   async updateSectorDefinition(_id: number, _data: Partial<import('../models/ISectorDefinition').ISectorDefinition>): Promise<import('../models/ISectorDefinition').ISectorDefinition> { throw new Error('Not implemented'); }
+
+  // --- BD Leads Folder Operations ---
+  async createBdLeadFolder(_leadTitle: string, _originatorName: string): Promise<void> { throw new Error('Not implemented'); }
+  async checkFolderExists(_path: string): Promise<boolean> { throw new Error('Not implemented'); }
+  async createFolder(_path: string): Promise<void> { throw new Error('Not implemented'); }
+  async renameFolder(_oldPath: string, _newPath: string): Promise<void> { throw new Error('Not implemented'); }
+
+  // --- Assignment Mappings ---
+  async getAssignmentMappings(): Promise<import('../models/IAssignmentMapping').IAssignmentMapping[]> { return []; }
+  async createAssignmentMapping(_data: Partial<import('../models/IAssignmentMapping').IAssignmentMapping>): Promise<import('../models/IAssignmentMapping').IAssignmentMapping> { throw new Error('Not implemented'); }
+  async updateAssignmentMapping(_id: number, _data: Partial<import('../models/IAssignmentMapping').IAssignmentMapping>): Promise<import('../models/IAssignmentMapping').IAssignmentMapping> { throw new Error('Not implemented'); }
+  async deleteAssignmentMapping(_id: number): Promise<void> { throw new Error('Not implemented'); }
+
+  // --- Scorecard Reject / Archive ---
+  async rejectScorecard(_scorecardId: number, _reason: string): Promise<IGoNoGoScorecard> { throw new Error('Not implemented'); }
+  async archiveScorecard(_scorecardId: number, _archivedBy: string): Promise<IGoNoGoScorecard> { throw new Error('Not implemented'); }
 }

--- a/src/webparts/hbcProjectControls/services/columnMappings.ts
+++ b/src/webparts/hbcProjectControls/services/columnMappings.ts
@@ -1568,3 +1568,17 @@ export const PROJECT_TEAM_ASSIGNMENTS_COLUMNS = {
   assignedDate: 'AssignedDate',                // SP: DateTime
   isActive: 'IsActive',                        // SP: Yes/No
 } as const;
+
+/**
+ * List: Assignment_Mappings
+ * Interface: IAssignmentMapping
+ */
+export const ASSIGNMENT_MAPPINGS_COLUMNS = {
+  id: 'ID',                                    // SP: Auto-generated
+  region: 'Region',                            // SP: Single Line of Text
+  sector: 'Sector',                            // SP: Single Line of Text
+  assignmentType: 'AssignmentType',            // SP: Choice (Estimator, Director)
+  assigneeUserId: 'AssigneeUserId',            // SP: Single Line of Text
+  assigneeDisplayName: 'AssigneeDisplayName',  // SP: Single Line of Text
+  assigneeEmail: 'AssigneeEmail',              // SP: Single Line of Text
+} as const;

--- a/src/webparts/hbcProjectControls/utils/constants.ts
+++ b/src/webparts/hbcProjectControls/utils/constants.ts
@@ -45,6 +45,7 @@ export const HUB_LISTS = {
   SECURITY_GROUP_MAPPINGS: 'Security_Group_Mappings',
   PROJECT_TEAM_ASSIGNMENTS: 'Project_Team_Assignments',
   SECTOR_DEFINITIONS: 'Sector_Definitions',
+  ASSIGNMENT_MAPPINGS: 'Assignment_Mappings',
 } as const;
 
 export const PROJECT_LISTS = {
@@ -102,6 +103,7 @@ export const ROUTES = {
   PRECON: '/preconstruction',
   PRECON_GONOGO: '/preconstruction/gonogo',
   PRECON_PIPELINE: '/preconstruction/pipeline',
+  PRECON_PIPELINE_GONOGO: '/preconstruction/pipeline/gonogo',
   PRECON_TRACKING: '/preconstruction/precon-tracker',
   PRECON_ESTIMATE_LOG: '/preconstruction/estimate-log',
   PRECON_KICKOFF_LIST: '/preconstruction/kickoff-list',
@@ -263,3 +265,12 @@ export const SCORE_THRESHOLDS = {
 } as const;
 
 export const DEFAULT_HUB_SITE_URL = 'https://hedrickbrotherscom.sharepoint.com/sites/HBCentral';
+
+// BD Leads Document Library
+export const BD_LEADS_SITE_URL = 'https://hedrickbrotherscom.sharepoint.com/sites/PXPortfolioDashboard';
+export const BD_LEADS_LIBRARY = 'BD Leads';
+export const BD_LEADS_SUBFOLDERS = [
+  'Client Information', 'Correspondence', 'Proposal Documents',
+  'Site and Project Plans', 'Financial Estimates', 'Evaluations and Scorecards',
+  'Contracts and Legal', 'Media and Visuals', 'Archives',
+];

--- a/src/webparts/hbcProjectControls/utils/permissions.ts
+++ b/src/webparts/hbcProjectControls/utils/permissions.ts
@@ -135,6 +135,12 @@ export const PERMISSIONS = {
   PERMISSION_TEMPLATES_MANAGE: 'permission:templates:manage',
   PERMISSION_PROJECT_TEAM_MANAGE: 'permission:project_team:manage',
   PERMISSION_PROJECT_TEAM_VIEW: 'permission:project_team:view',
+
+  // Go/No-Go Review (Director/Committee)
+  GONOGO_REVIEW: 'gonogo:review',
+
+  // Assignment Mappings Admin
+  ADMIN_ASSIGNMENTS: 'admin:assignments:manage',
 } as const;
 
 export type PermissionKey = typeof PERMISSIONS[keyof typeof PERMISSIONS];
@@ -144,6 +150,7 @@ export const NAV_GROUP_ROLES: Record<string, string[]> = {
   Marketing: ['Marketing', 'Executive Leadership', 'Department Director', 'SharePoint Admin'],
   Preconstruction: ['BD Representative', 'Estimating Coordinator', 'Preconstruction Team', 'Executive Leadership', 'Department Director', 'Legal', 'SharePoint Admin'],
   Operations: ['Operations Team', 'Executive Leadership', 'Department Director', 'Risk Management', 'Quality Control', 'Safety', 'IDS', 'SharePoint Admin'],
+  Accounting: ['Accounting Manager', 'Executive Leadership', 'Department Director', 'SharePoint Admin'],
   Admin: ['Executive Leadership', 'SharePoint Admin'],
 };
 
@@ -213,13 +220,14 @@ export const ROLE_PERMISSIONS: Record<string, string[]> = {
   ],
   'Executive Leadership': [
     PERMISSIONS.LEAD_READ,
-    PERMISSIONS.GONOGO_SCORE_COMMITTEE, PERMISSIONS.GONOGO_DECIDE, PERMISSIONS.GONOGO_READ,
+    PERMISSIONS.GONOGO_SCORE_COMMITTEE, PERMISSIONS.GONOGO_DECIDE, PERMISSIONS.GONOGO_READ, PERMISSIONS.GONOGO_REVIEW,
     PERMISSIONS.PRECON_READ, PERMISSIONS.PROPOSAL_READ,
     PERMISSIONS.WINLOSS_READ,
     PERMISSIONS.CONTRACT_READ, PERMISSIONS.CONTRACT_VIEW_FINANCIALS,
     PERMISSIONS.TURNOVER_READ, PERMISSIONS.CLOSEOUT_READ,
     PERMISSIONS.ESTIMATING_READ,
     PERMISSIONS.ADMIN_ROLES, PERMISSIONS.ADMIN_FLAGS, PERMISSIONS.ADMIN_CONFIG, PERMISSIONS.ADMIN_CONNECTIONS, PERMISSIONS.ADMIN_PROVISIONING,
+    PERMISSIONS.ADMIN_ASSIGNMENTS,
     PERMISSIONS.MEETING_SCHEDULE, PERMISSIONS.MEETING_READ,
     PERMISSIONS.STARTUP_CHECKLIST_SIGNOFF, PERMISSIONS.MARKETING_DASHBOARD_VIEW,
     PERMISSIONS.PMP_APPROVE, PERMISSIONS.PMP_FINAL_APPROVE, PERMISSIONS.PMP_SIGN,
@@ -237,7 +245,7 @@ export const ROLE_PERMISSIONS: Record<string, string[]> = {
   ],
   'Department Director': [
     PERMISSIONS.LEAD_READ,
-    PERMISSIONS.GONOGO_SCORE_COMMITTEE, PERMISSIONS.GONOGO_DECIDE, PERMISSIONS.GONOGO_READ,
+    PERMISSIONS.GONOGO_SCORE_COMMITTEE, PERMISSIONS.GONOGO_DECIDE, PERMISSIONS.GONOGO_READ, PERMISSIONS.GONOGO_REVIEW,
     PERMISSIONS.PRECON_READ, PERMISSIONS.PROPOSAL_READ,
     PERMISSIONS.WINLOSS_READ,
     PERMISSIONS.CONTRACT_READ, PERMISSIONS.CONTRACT_VIEW_FINANCIALS,


### PR DESCRIPTION
## Summary

- **Navigation cleanup (Phase 21):** Reduced Preconstruction nav from 10→7 items, added Accounting nav group, moved Go/No-Go Tracker to PipelinePage as a second tab
- **Lead-to-site workflow (Phase 22):** Replaced ScorecardStatus enum (8→10 values), added admin-configurable assignment mappings (Director/Estimator per Region/Sector), BD Leads folder creation on new lead, full GoNoGoScorecard rewrite with Director review/reject + Committee scoring/decision + archive flow, PipelinePage Go/No-Go Tracker with Pending/Archive sub-tabs, 8 new service methods (200 total)
- **Simplified Go/No-Go decision flow:** Removed project code entry, kickoff creation, and kickoff scheduler from the GO decision confirmation. Committee now confirms via a simple dialog, and a notification is sent to the Estimating Coordinator to begin preconstruction. Project code assignment happens later via the Job Number Request form.

## Test plan

- [ ] Navigate to a scorecard in `AwaitingCommitteeScoring` status
- [ ] Click "GO" → verify simple Confirm/Cancel dialog (no project code field)
- [ ] Confirm GO → verify toast says "GO decision recorded. Estimating coordinator notified."
- [ ] Click "CONDITIONAL GO" → verify only conditions textarea + Confirm/Cancel (no project code field)
- [ ] Verify no kickoff scheduler modal appears after GO decision
- [ ] Verify notification fires (check console for mock notification)
- [ ] Verify Preconstruction nav shows 7 items (no Precon Tracker, Estimate Log, Accounting Queue)
- [ ] Verify new Accounting nav group appears for Accounting Manager role
- [ ] Verify PipelinePage has Pipeline + Go/No-Go Tracker tabs
- [ ] Run `npx tsc --noEmit` — clean compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)