### PR TITLE
Implement Project Selection Behavior (Phase 26)

### DIFF
--- a/src/webparts/hbcProjectControls/HbcProjectControlsWebPart.ts
+++ b/src/webparts/hbcProjectControls/HbcProjectControlsWebPart.ts
@@ -23,6 +23,7 @@ export default class HbcProjectControlsWebPart extends BaseClientSideWebPart<IHb
   public render(): void {
     const element: React.ReactElement<IAppProps> = React.createElement(App, {
       dataService: this._dataService,
+      siteUrl: this.context.pageContext.web.absoluteUrl,
     });
 
     ReactDom.render(element, this.domElement);

--- a/src/webparts/hbcProjectControls/components/App.tsx
+++ b/src/webparts/hbcProjectControls/components/App.tsx
@@ -61,6 +61,7 @@ import { PERMISSIONS } from '../utils/permissions';
 
 export interface IAppProps {
   dataService: IDataService;
+  siteUrl?: string;  // Provided by SPFx; undefined in dev server
 }
 
 const NotFoundPage: React.FC = () => (
@@ -225,11 +226,11 @@ const AppRoutes: React.FC = () => (
   </Routes>
 );
 
-export const App: React.FC<IAppProps> = ({ dataService }) => {
+export const App: React.FC<IAppProps> = ({ dataService, siteUrl }) => {
   return (
     <FluentProvider theme={hbcLightTheme}>
       <ErrorBoundary>
-        <AppProvider dataService={dataService}>
+        <AppProvider dataService={dataService} siteUrl={siteUrl}>
           <ToastProvider>
             <HashRouter>
               <AppShell>

--- a/src/webparts/hbcProjectControls/components/shared/ProjectPicker.tsx
+++ b/src/webparts/hbcProjectControls/components/shared/ProjectPicker.tsx
@@ -9,9 +9,10 @@ import { getStageLabel, isActiveStage } from '../../utils/stageEngine';
 interface IProjectPickerProps {
   selected: ISelectedProject | null;
   onSelect: (project: ISelectedProject | null) => void;
+  locked?: boolean;
 }
 
-export const ProjectPicker: React.FC<IProjectPickerProps> = ({ selected, onSelect }) => {
+export const ProjectPicker: React.FC<IProjectPickerProps> = ({ selected, onSelect, locked }) => {
   const { leads, fetchLeads } = useLeads();
   const { dataService, currentUser, resolvedPermissions } = useAppContext();
   const [query, setQuery] = React.useState('');
@@ -109,6 +110,25 @@ export const ProjectPicker: React.FC<IProjectPickerProps> = ({ selected, onSelec
     onSelect(null);
     setQuery('');
   };
+
+  if (locked && selected) {
+    return (
+      <div style={{ padding: '8px 12px' }}>
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 6,
+          padding: '6px 10px', borderRadius: 6,
+          border: `1px solid ${HBC_COLORS.gray200}`,
+          backgroundColor: HBC_COLORS.gray50,
+          fontSize: 13, minHeight: 32,
+        }}>
+          <span style={{ flex: 1, fontWeight: 500, color: HBC_COLORS.navy, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {selected.projectName}
+          </span>
+          <span style={{ color: HBC_COLORS.gray400, fontSize: 11 }}>{selected.projectCode}</span>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div ref={containerRef} style={{ position: 'relative', padding: '8px 12px' }}>

--- a/src/webparts/hbcProjectControls/services/IDataService.ts
+++ b/src/webparts/hbcProjectControls/services/IDataService.ts
@@ -381,6 +381,9 @@ export interface IDataService {
   // Scorecard archive (Phase 22)
   rejectScorecard(scorecardId: number, reason: string): Promise<IGoNoGoScorecard>;
   archiveScorecard(scorecardId: number, archivedBy: string): Promise<IGoNoGoScorecard>;
+
+  // Project site URL targeting (Phase 26)
+  setProjectSiteUrl(siteUrl: string | null): void;
 }
 
 export interface IActiveProjectsQueryOptions extends IListQueryOptions {

--- a/src/webparts/hbcProjectControls/services/MockDataService.ts
+++ b/src/webparts/hbcProjectControls/services/MockDataService.ts
@@ -5372,6 +5372,10 @@ export class MockDataService implements IDataService {
     return { ...scorecard };
   }
 
+  public setProjectSiteUrl(_siteUrl: string | null): void {
+    // No-op: mock data uses in-memory arrays filtered by projectCode
+  }
+
   async archiveScorecard(scorecardId: number, archivedBy: string): Promise<IGoNoGoScorecard> {
     await delay();
     const { scorecard, index } = this.findScorecardOrThrow(scorecardId);

--- a/src/webparts/hbcProjectControls/services/SharePointDataService.ts
+++ b/src/webparts/hbcProjectControls/services/SharePointDataService.ts
@@ -1354,4 +1354,13 @@ export class SharePointDataService implements IDataService {
   // --- Scorecard Reject / Archive ---
   async rejectScorecard(_scorecardId: number, _reason: string): Promise<IGoNoGoScorecard> { throw new Error('Not implemented'); }
   async archiveScorecard(_scorecardId: number, _archivedBy: string): Promise<IGoNoGoScorecard> { throw new Error('Not implemented'); }
+
+  // --- Project Site URL Targeting ---
+  private _projectSiteUrl: string | null = null;
+
+  public setProjectSiteUrl(siteUrl: string | null): void {
+    this._projectSiteUrl = siteUrl;
+    // When PnP project-web methods are implemented, this will create
+    // a new SPFI web instance: this._projectWeb = Web([this.sp.web, siteUrl])
+  }
 }

--- a/src/webparts/hbcProjectControls/utils/siteDetector.ts
+++ b/src/webparts/hbcProjectControls/utils/siteDetector.ts
@@ -24,13 +24,26 @@ export function detectSiteContext(
   if (hubSiteUrl) {
     const urlParts = currentSiteUrl.split('/');
     const siteName = urlParts[urlParts.length - 1] || urlParts[urlParts.length - 2];
-    const projectCodeMatch = siteName.match(/(\d{2}-\d{3}-\d{2})/);
+
+    // Try dashed format first (25-042-01)
+    const dashedMatch = siteName.match(/(\d{2}-\d{3}-\d{2})/);
+    let projectCode: string | undefined;
+    if (dashedMatch) {
+      projectCode = dashedMatch[1];
+    } else {
+      // Try dashless 7-digit format (2504201) — provisioned sites strip dashes
+      const dashlessMatch = siteName.match(/(\d{7})/);
+      if (dashlessMatch) {
+        const d = dashlessMatch[1];
+        projectCode = `${d.substring(0, 2)}-${d.substring(2, 5)}-${d.substring(5, 7)}`;
+      }
+    }
 
     return {
       siteUrl: currentSiteUrl,
       hubSiteUrl,
       isHubSite: false,
-      projectCode: projectCodeMatch ? projectCodeMatch[1] : undefined,
+      projectCode,
     };
   }
 


### PR DESCRIPTION
## Summary
- Wire `siteDetector.ts` into AppContext for automatic hub vs project-site detection based on SP site URL
- Auto-select and lock the ProjectPicker on project-specific SharePoint sites (e.g., `https://…/sites/2504201`)
- Add `hubOnly` flag to navigation items — hides multi-project views (Pipeline, Estimating Dashboard, Active Projects, etc.) when a project is selected
- Show dynamic Lead Detail and Go/No-Go nav items under Preconstruction when a project is selected
- Add `setProjectSiteUrl()` method to IDataService for future dual-web SharePoint data routing
- Fix dashless project code matching in siteDetector (supports `2504201` → `25-042-01` conversion)

## Changes
- **HbcProjectControlsWebPart.ts**: Pass `pageContext.web.absoluteUrl` as `siteUrl` prop
- **App.tsx**: Thread `siteUrl?` prop to AppProvider
- **AppContext.tsx**: `isProjectSite` flag, auto-select logic, `handleSetSelectedProject` guard, `setProjectSiteUrl` effect
- **ProjectPicker.tsx**: `locked?` prop for read-only static display
- **NavigationSidebar.tsx**: `hubOnly` item flag, dynamic project-scoped items, locked picker pass-through
- **siteDetector.ts**: Two-pass regex (dashed + dashless 7-digit format)
- **IDataService/MockDataService/SharePointDataService**: `setProjectSiteUrl()` method (#202)
- **CLAUDE.md**: Updated §3, §4 (Site Detection Pattern), §5, §7, §9, §15, §16 (+pitfalls #33–34)

## Test plan
- [ ] `npm run dev` — hub mode: picker interactive, all nav items visible, select project → hubOnly items hidden, dynamic items appear, clear → restores
- [ ] Verify locked ProjectPicker renders static display with project name + code
- [ ] Verify siteDetector handles `https://…/sites/2504201` → `projectCode: '25-042-01'`
- [ ] `npx tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)