### PR TITLE
Fix Current Pursuits column truncation with minWidth support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,7 +435,7 @@ sharepoint/solution/debug/          # SPFx solution package output (auto-generat
 | CollapsibleSection | components/shared/CollapsibleSection.tsx | title, subtitle?, defaultExpanded?, badge?, children | ~0 (available) |
 | ConditionBuilder | components/shared/ConditionBuilder.tsx | assignment, onChange, onRemove, disabled? | ~1 |
 | ConfirmDialog | components/shared/ConfirmDialog.tsx | open, title, message, confirmLabel?, cancelLabel?, onConfirm, onCancel, danger? | ~1 |
-| DataTable | components/shared/DataTable.tsx | columns: IDataTableColumn<T>[], items, keyExtractor, isLoading?, onRowClick?, sortField?, onSort?, pageSize? | ~12 |
+| DataTable | components/shared/DataTable.tsx | columns: IDataTableColumn<T>[] (key, header, render, sortable?, width?, minWidth?, hideOnMobile?), items, keyExtractor, isLoading?, onRowClick?, sortField?, onSort?, pageSize? | ~12 |
 | EmptyState | components/shared/EmptyState.tsx | title, description?, icon?, action? | internal (DataTable) |
 | ErrorBoundary | components/shared/ErrorBoundary.tsx | children, fallback? | 1 (App.tsx root) |
 | ExportButtons | components/shared/ExportButtons.tsx | pdfElementId?, data?, filename, title? | ~10 |

--- a/src/webparts/hbcProjectControls/components/pages/precon/EstimatingDashboard.tsx
+++ b/src/webparts/hbcProjectControls/components/pages/precon/EstimatingDashboard.tsx
@@ -334,40 +334,40 @@ export const EstimatingDashboard: React.FC = () => {
 
   // Current Pursuits columns — no fixed width on text columns, removed Kick-Off button
   const pursuitColumns: IDataTableColumn<IEstimatingTracker>[] = React.useMemo(() => [
-    { key: 'Title', header: 'Project', sortable: true, render: (r) => (
+    { key: 'Title', header: 'Project', sortable: true, minWidth: '180px', render: (r) => (
       <span style={{ fontWeight: 500, color: HBC_COLORS.navy, whiteSpace: 'nowrap' }}>{r.Title}</span>
     )},
     { key: 'ProjectCode', header: 'Code', sortable: true, width: '90px', render: (r) => (
       <span style={{ fontFamily: 'monospace', fontSize: '12px', whiteSpace: 'nowrap' }}>{r.ProjectCode || '-'}</span>
     )},
-    { key: 'Source', header: 'Source', sortable: true, render: (r) => (
+    { key: 'Source', header: 'Source', sortable: true, minWidth: '100px', render: (r) => (
       <InlineSelect recordId={r.id} field="Source" value={r.Source} options={sourceOptions} updateFn={handleInlineUpdate} disabled={!canEdit} />
     )},
-    { key: 'DeliverableType', header: 'Type', sortable: true, render: (r) => (
+    { key: 'DeliverableType', header: 'Type', sortable: true, minWidth: '100px', render: (r) => (
       <InlineSelect recordId={r.id} field="DeliverableType" value={r.DeliverableType} options={typeOptions} updateFn={handleInlineUpdate} disabled={!canEdit} />
     )},
-    { key: 'SubBidsDue', header: 'Sub Bids Due', render: (r) => (
+    { key: 'SubBidsDue', header: 'Sub Bids Due', minWidth: '120px', render: (r) => (
       <InlineDate recordId={r.id} field="SubBidsDue" value={r.SubBidsDue} updateFn={handleInlineUpdate} disabled={!canEdit} />
     )},
-    { key: 'PreSubmissionReview', header: 'Pre-Sub Review', render: (r) => (
+    { key: 'PreSubmissionReview', header: 'Pre-Sub Review', minWidth: '120px', render: (r) => (
       <InlineDate recordId={r.id} field="PreSubmissionReview" value={r.PreSubmissionReview} updateFn={handleInlineUpdate} disabled={!canEdit} />
     )},
-    { key: 'WinStrategyMeeting', header: 'Win Strategy', render: (r) => (
+    { key: 'WinStrategyMeeting', header: 'Win Strategy', minWidth: '120px', render: (r) => (
       <InlineDate recordId={r.id} field="WinStrategyMeeting" value={r.WinStrategyMeeting} updateFn={handleInlineUpdate} disabled={!canEdit} />
     )},
-    { key: 'DueDate_OutTheDoor', header: 'Due (OTD)', sortable: true, render: (r) => (
+    { key: 'DueDate_OutTheDoor', header: 'Due (OTD)', sortable: true, minWidth: '120px', render: (r) => (
       <InlineDate recordId={r.id} field="DueDate_OutTheDoor" value={r.DueDate_OutTheDoor} updateFn={handleInlineUpdate} disabled={!canEdit} />
     )},
-    { key: 'LeadEstimator', header: 'Estimator', sortable: true, render: (r) => (
+    { key: 'LeadEstimator', header: 'Estimator', sortable: true, minWidth: '120px', render: (r) => (
       <InlineInput recordId={r.id} field="LeadEstimator" value={r.LeadEstimator || ''} updateFn={handleInlineUpdate} disabled={!canEdit} />
     )},
-    { key: 'Contributors', header: 'Contributors', width: '100px', render: (r) => (
+    { key: 'Contributors', header: 'Contributors', width: '130px', render: (r) => (
       <InlineInput recordId={r.id} field="Contributors" value={(r.Contributors || []).join(', ')} updateFn={(id, data) => {
         const val = String((data as Record<string, unknown>).Contributors || '');
         return handleInlineUpdate(id, { Contributors: val.split(',').map(s => s.trim()).filter(Boolean) } as unknown as Partial<IEstimatingTracker>);
       }} disabled={!canEdit} />
     )},
-    { key: 'PX_ProjectExecutive', header: 'PX', render: (r) => (
+    { key: 'PX_ProjectExecutive', header: 'PX', minWidth: '90px', render: (r) => (
       <InlineInput recordId={r.id} field="PX_ProjectExecutive" value={r.PX_ProjectExecutive || ''} updateFn={handleInlineUpdate} disabled={!canEdit} />
     )},
     ...chkHeaders.map(ch => ({
@@ -383,7 +383,7 @@ export const EstimatingDashboard: React.FC = () => {
         </span>
       ),
     })),
-    { key: 'EstimatedCostValue', header: 'Est. Value', sortable: true, width: '100px', render: (r) => (
+    { key: 'EstimatedCostValue', header: 'Est. Value', sortable: true, width: '110px', render: (r) => (
       <InlineNumber recordId={r.id} field="EstimatedCostValue" value={r.EstimatedCostValue} updateFn={handleInlineUpdate} disabled={!canEdit} format={formatCurrencyCompact} />
     )},
   ], [handleCheckToggle, handleInlineUpdate, canEdit, sourceOptions, typeOptions]);

--- a/src/webparts/hbcProjectControls/components/shared/DataTable.tsx
+++ b/src/webparts/hbcProjectControls/components/shared/DataTable.tsx
@@ -10,6 +10,7 @@ export interface IDataTableColumn<T> {
   render: (item: T) => React.ReactNode;
   sortable?: boolean;
   width?: string;
+  minWidth?: string;
   hideOnMobile?: boolean;
 }
 
@@ -98,6 +99,7 @@ export function DataTable<T>({
                     cursor: col.sortable && onSort ? 'pointer' : 'default',
                     userSelect: col.sortable ? 'none' : undefined,
                     width: col.width,
+                    minWidth: col.minWidth,
                   }}
                   onClick={() => col.sortable && onSort && onSort(col.key)}
                 >


### PR DESCRIPTION
## Summary
- Add optional `minWidth` prop to `IDataTableColumn` interface in DataTable — backward-compatible, no impact on existing consumers
- Apply targeted `minWidth` values to Current Pursuits columns: date inputs (120px), name fields (120px), select dropdowns (100px), project title (180px)
- Widen Contributors (100→130px) and Est. Value (100→110px) to prevent clipping

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] `npx tsc --noEmit -p dev/tsconfig.json` passes (verified)
- [ ] Date columns show full `mm/dd/yyyy` without truncation
- [ ] Estimator / PX fields display full names without clipping
- [ ] Checkbox columns remain compact at 40px
- [ ] Horizontal scroll activates on narrow viewports
- [ ] Inline editing still works (click date, change, blur to save)
- [ ] Precon Tracker and Estimate Log tabs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)