### PR TITLE
feat: React 18 + Fluent UI v9 migration

### DIFF
--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { App } from '@components/App';
 import { MockDataService } from '@services/MockDataService';
 import { RoleName } from '@models/enums';
@@ -38,4 +38,7 @@ const DevRoot: React.FC = () => {
   );
 };
 
-ReactDOM.render(<DevRoot />, document.getElementById('root'));
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  createRoot(rootElement).render(<DevRoot />);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
         "@pnp/sp": "^4.4.1",
         "html2canvas": "^1.4.1",
         "jspdf": "^2.5.2",
-        "react": "17.0.1",
-        "react-dom": "17.0.1",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
         "react-router-dom": "^6.22.3",
         "recharts": "^2.12.3",
         "tslib": "^2.6.2",
@@ -35,10 +35,10 @@
         "@microsoft/sp-build-web": "1.21.1",
         "@microsoft/sp-module-interfaces": "1.21.1",
         "@testing-library/jest-dom": "^6.4.2",
-        "@testing-library/react": "^12.1.5",
+        "@testing-library/react": "^14.0.0",
         "@types/jest": "^29.5.12",
-        "@types/react": "17.0.67",
-        "@types/react-dom": "17.0.21",
+        "@types/react": "18.2.0",
+        "@types/react-dom": "18.2.0",
         "@types/react-router-dom": "^5.3.3",
         "@types/webpack-env": "^1.18.8",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -1137,9 +1137,9 @@
       }
     },
     "node_modules/@fluentui/priority-overflow": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.2.1.tgz",
-      "integrity": "sha512-WH5dv54aEqWo/kKQuADAwjv66W6OUMFllQMjpdkrktQp7pu4JXtmF60iYcp9+iuIX9iCeW01j8gNTU08MQlfIQ==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.3.0.tgz",
+      "integrity": "sha512-yaBC0R4e+4ZlCWDulB5S+xBrlnLwfzdg68GaarCqQO8OHjLg7Ah05xTj7PsAYcoHeEg/9vYeBwGXBpRO8+Tjqw==",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.1"
@@ -1174,15 +1174,15 @@
       }
     },
     "node_modules/@fluentui/react-accordion": {
-      "version": "9.8.16",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.8.16.tgz",
-      "integrity": "sha512-UkgjCyKMy9C+IKFtnovDH8UZO1hebI45KDVViaPchc5oNV3hha9dFevqP8Iisr65muIFZQuloetr5saDvGadxA==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.9.0.tgz",
+      "integrity": "sha512-vK7LTTRoICs/k7zRZkmBpX5v8Ig72xHdBM2uzUT/Az+Qk+pTYGzxz0pogC/Y8jq8Ynn0DhVgJ7IGm25/L19A+g==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-aria": "^9.17.8",
+        "@fluentui/react-aria": "^9.17.9",
         "@fluentui/react-context-selector": "^9.2.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-motion": "^9.11.6",
         "@fluentui/react-motion-components-preview": "^0.15.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
@@ -1223,13 +1223,13 @@
       }
     },
     "node_modules/@fluentui/react-aria": {
-      "version": "9.17.8",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.17.8.tgz",
-      "integrity": "sha512-u7RIXvQZTX5RKGvbNVSGO/cbbY3n+4c8TMQMRhujU97mpXGoOQR32xy5PfoS+WPXeIlblPqeg/NS20q+9kfWwg==",
+      "version": "9.17.9",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.17.9.tgz",
+      "integrity": "sha512-L0/lin/zKzTcYDPM3i+fMeP5OtbFVfwxMHhPewLy7nbFnFb0p7dbWCxLE6r0C6yq4JFBk0nA0eWy9ox2BOMTRA==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-utilities": "^9.26.1",
@@ -1243,20 +1243,20 @@
       }
     },
     "node_modules/@fluentui/react-avatar": {
-      "version": "9.9.14",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.9.14.tgz",
-      "integrity": "sha512-jaXnnZ5ubbgzVud3x8D63iHg8zHV1McNc7/XdOwfmkWop/6ve5bWhTP2l/K0ftobXBIkA+kkwhEbhylHaCQz7g==",
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.10.0.tgz",
+      "integrity": "sha512-GQuKzoTm/ABEnw97It6/7Ut21b3ZuB+F00yVkjS30xAN+q5mYIKdVcgXykYE9LiDJHp21CmrgtcyrThlDxo4nw==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-badge": "^9.4.13",
+        "@fluentui/react-badge": "^9.4.14",
         "@fluentui/react-context-selector": "^9.2.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
-        "@fluentui/react-popover": "^9.13.0",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
+        "@fluentui/react-popover": "^9.13.1",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-tooltip": "^9.9.0",
+        "@fluentui/react-tooltip": "^9.9.1",
         "@fluentui/react-utilities": "^9.26.1",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
@@ -1269,13 +1269,13 @@
       }
     },
     "node_modules/@fluentui/react-badge": {
-      "version": "9.4.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.4.13.tgz",
-      "integrity": "sha512-rgmjqg99uml+HmA0G1iSHnED2e/P7ZwYX0iGPIQL8HpGG9S/3U/WHXqYgidl7kjmdANcNmdbqDjaU1ntx4+BcA==",
+      "version": "9.4.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.4.14.tgz",
+      "integrity": "sha512-13+0IAGhPoHrfcX2nIl47cUgqO5fyvfq6rNPAMjyxz/ZCvX/TFiAglq8P7CRyGHQWBvaUTHFME2//gy8dW2new==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -1290,16 +1290,16 @@
       }
     },
     "node_modules/@fluentui/react-breadcrumb": {
-      "version": "9.3.15",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.3.15.tgz",
-      "integrity": "sha512-7Y5JbgrgUwIJPWcQNohLJUVmIkGsTk8rqjfL0OyBscRRA3hLM9F0KOf4BK3V0u/NokmCglkOvXYgQ3i3PJBp3Q==",
+      "version": "9.3.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.3.16.tgz",
+      "integrity": "sha512-irgluPPOcq1pF7CFP18IGzTZS1TWuM7XwU51OopSNbdnyij5WgMySZBVcIiDk0jC2yL2U2SZefT+sDsSA3ZwRg==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-aria": "^9.17.8",
-        "@fluentui/react-button": "^9.8.0",
+        "@fluentui/react-aria": "^9.17.9",
+        "@fluentui/react-button": "^9.8.1",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
-        "@fluentui/react-link": "^9.7.2",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
+        "@fluentui/react-link": "^9.7.3",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -1315,15 +1315,15 @@
       }
     },
     "node_modules/@fluentui/react-button": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.8.0.tgz",
-      "integrity": "sha512-pBkh7lQIHx8lYf5ZxJCOlbzjROT6w3Qw4ufP6f2ImhJCOgvDwSlwKhod++tIhnjYRmN6xIGvhFuFvw6Ju5TsLg==",
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.8.1.tgz",
+      "integrity": "sha512-/YaLzsK57kr91b4gDIINpz0fb4KxdhfzZA6/Ltymm15CwpZ/qOgVt6oFLPunfi/GlUraEnH7EaacJ1kVffneCA==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.8",
+        "@fluentui/react-aria": "^9.17.9",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -1339,16 +1339,16 @@
       }
     },
     "node_modules/@fluentui/react-card": {
-      "version": "9.5.9",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.5.9.tgz",
-      "integrity": "sha512-xNO2QmB2uQfyAng/xxI8YvD4O56JpmgVKtK9DLwffkb5Nxt+e0elHIDIIN2wzcGTXLkhlQ61Ou3b3etwCRjZfg==",
+      "version": "9.5.10",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.5.10.tgz",
+      "integrity": "sha512-WPDm1lpfe87eWoiht/Q4NGmLVqQD5voeCr4MWZz5Pa9EH9d4vX6eemtJjgrnpvXOvGlVhlOHLhx7lz7FmrUheQ==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
-        "@fluentui/react-text": "^9.6.13",
+        "@fluentui/react-text": "^9.6.14",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
         "@griffel/react": "^1.5.32",
@@ -1362,20 +1362,20 @@
       }
     },
     "node_modules/@fluentui/react-carousel": {
-      "version": "9.9.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.9.1.tgz",
-      "integrity": "sha512-C7LtFgxPQutB/Vw03f6jtg51RDgZBrqBwTjzdoXBBi0qPXTFihH1wn57IM5WDhQxgbR5vFrWfiaLO3UwXlpEXg==",
+      "version": "9.9.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.9.2.tgz",
+      "integrity": "sha512-+NHu80Ylv4hhU2LdzmHH/r6N8dm8bKWtRDjm98emC4zEwZGhFltO4QhtafCM3E1NiICFKCrF7RRQlsjAD8YbVQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-aria": "^9.17.8",
-        "@fluentui/react-button": "^9.8.0",
+        "@fluentui/react-aria": "^9.17.9",
+        "@fluentui/react-button": "^9.8.1",
         "@fluentui/react-context-selector": "^9.2.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-tooltip": "^9.9.0",
+        "@fluentui/react-tooltip": "^9.9.1",
         "@fluentui/react-utilities": "^9.26.1",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1",
@@ -1391,15 +1391,15 @@
       }
     },
     "node_modules/@fluentui/react-checkbox": {
-      "version": "9.5.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.5.13.tgz",
-      "integrity": "sha512-Mgdu2796TMvuUAVKh//OSuB5Meb6Y5SDrY6pwTvozTHxfsXFAXbEwrIGYiwYtg2pUIr3/gL3Pe1o9ptyy0MGxg==",
+      "version": "9.5.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.5.14.tgz",
+      "integrity": "sha512-0tCAZZwiwK618/LtFueyJ+4o9p+LbRf3KRMMkWWBNRqAlclno8oQQ7lrPHYOjrvmVUPYi9Xg7Gt+ArckUQZEBw==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.4.13",
+        "@fluentui/react-field": "^9.4.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
-        "@fluentui/react-label": "^9.3.13",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
+        "@fluentui/react-label": "^9.3.14",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -1415,14 +1415,14 @@
       }
     },
     "node_modules/@fluentui/react-color-picker": {
-      "version": "9.2.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.13.tgz",
-      "integrity": "sha512-wRxWVHKug5fPthP0ta9BZ2geq3z9Fku8QUpWqvwQNpcOthHotJs2bvc7YPEILYZtUk7sF8OX7uAEWrjo5rrX2A==",
+      "version": "9.2.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.14.tgz",
+      "integrity": "sha512-ZsdCm5j2/Q5WOpgDHX5X3AOJwP3AOf9hNlhTbt/kjDnLmkmHETkqyo5YPVeWoOfjSyEWw5ARQoN5higL7dIs2Q==",
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^3.3.4",
         "@fluentui/react-context-selector": "^9.2.14",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -1438,17 +1438,17 @@
       }
     },
     "node_modules/@fluentui/react-combobox": {
-      "version": "9.16.14",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.16.14.tgz",
-      "integrity": "sha512-CQLdlxU5qK0XEBRCJuFOo1GTSGd0Ii3uJ/jyYe2B1ID2buiwOfDQDanM3ISuB1gv/Cmi2S6yoRfjMemN8TKykQ==",
+      "version": "9.16.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.16.15.tgz",
+      "integrity": "sha512-SuffNVAq3QvZShAK0BiO/X0azjkoG8X6mD9sFitU80Nj/JZeDABNekd/da+NuBQ3IHjVspgj8336vIr2epMLyg==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.8",
+        "@fluentui/react-aria": "^9.17.9",
         "@fluentui/react-context-selector": "^9.2.14",
-        "@fluentui/react-field": "^9.4.13",
+        "@fluentui/react-field": "^9.4.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-portal": "^9.8.10",
         "@fluentui/react-positioning": "^9.20.12",
         "@fluentui/react-shared-contexts": "^9.26.1",
@@ -1559,16 +1559,16 @@
       }
     },
     "node_modules/@fluentui/react-dialog": {
-      "version": "9.16.6",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.16.6.tgz",
-      "integrity": "sha512-GD6GXI7MiMytdR1eTFrN3svfS9DKFQqimS35vKx0+ysizoYYahRdATOGLXjUxoj77X5UGfoeysIXr9f1ZcIs5w==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.17.0.tgz",
+      "integrity": "sha512-TCvpV7snLJA0cilZ9Q+TCMCAy4RfgMSHa4JHFay0aQ0oKKSMBQEPRsXzjjvzVlRuvpzzmMw2ZGM9dRYchj6bRw==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.8",
+        "@fluentui/react-aria": "^9.17.9",
         "@fluentui/react-context-selector": "^9.2.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-motion": "^9.11.6",
         "@fluentui/react-motion-components-preview": "^0.15.0",
         "@fluentui/react-portal": "^9.8.10",
@@ -1587,12 +1587,12 @@
       }
     },
     "node_modules/@fluentui/react-divider": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.6.0.tgz",
-      "integrity": "sha512-J8xfnmitXiA0FVxvaTEVxWOZMXs7EtYy+uZ1rFU/g4yaOrC4Gl0BCBt/n4+e4Nuyvz5ne3ZU9KY9DS433QH9qA==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.6.1.tgz",
+      "integrity": "sha512-qadRByctDJFV7JYTlafAXvXXp5q2TmaBFjdjBMzz1a8+9N5sL6LzX3MoKgEcI32mmBDalaREY9JgrcAlIehf0g==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -1607,13 +1607,13 @@
       }
     },
     "node_modules/@fluentui/react-drawer": {
-      "version": "9.11.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.11.2.tgz",
-      "integrity": "sha512-DdPu8y0WiDmjdggy7BWf+qM+mUVQCaD1+pF/fY2P40kBVS+cpaoRr6qOhZnIyrWeec3+ThtkTDnS3vj1pJ7eCA==",
+      "version": "9.11.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.11.3.tgz",
+      "integrity": "sha512-VtNsSsnmYIXIsHyHMNM8XXZZ84JcJE28lQITJ8JhK4w06yIgBpNnody2LIVYD9ndc3f6DSodt8ikgBUdXBOjog==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-dialog": "^9.16.6",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-dialog": "^9.17.0",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-motion": "^9.11.6",
         "@fluentui/react-motion-components-preview": "^0.15.0",
         "@fluentui/react-portal": "^9.8.10",
@@ -1632,15 +1632,15 @@
       }
     },
     "node_modules/@fluentui/react-field": {
-      "version": "9.4.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.4.13.tgz",
-      "integrity": "sha512-qGTTqdLlrllV3b2DYIGrrGD82Bp0WZR0GR30iT+Y9K3fEh0jhXZ5CmBuNKfy8XbWujfAiHpCv7z5zKAv2rKvmQ==",
+      "version": "9.4.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.4.14.tgz",
+      "integrity": "sha512-2x+ES49sWkQQ52NOEj4VazD9/CUvTjH+TbGhvVaMplbTGmaqQ00Lfcg56Cd1kweBnskyS4EuwmbXiDWBIoK+Wg==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-context-selector": "^9.2.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
-        "@fluentui/react-label": "^9.3.13",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
+        "@fluentui/react-label": "^9.3.14",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -1702,12 +1702,12 @@
       }
     },
     "node_modules/@fluentui/react-image": {
-      "version": "9.3.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.3.13.tgz",
-      "integrity": "sha512-814opBhEi8oeNaYxapNL8GQqWxLScuRw/QNX1OeCqKvoGNHOHLlqanV4IYzIgJxCzTTgSg/y6JJ1NadKcDdwZQ==",
+      "version": "9.3.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.3.14.tgz",
+      "integrity": "sha512-1e5MmOLhxbfF4+Nk235eOXREm9dkwCH06L1oNKZKWnwtAZBOmTwPspIW0ttXCvJtllaXXeKAeBexM3jLqG5VRw==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -1745,15 +1745,15 @@
       }
     },
     "node_modules/@fluentui/react-infolabel": {
-      "version": "9.4.14",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.14.tgz",
-      "integrity": "sha512-qFN9QVolEqZv/tizsmGkPHNNf/eQxMJc/woTQgj2WKRTuTlaYmAG07MC1giBFV58/agUyf6j4miEcDUcFiEpSw==",
+      "version": "9.4.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.15.tgz",
+      "integrity": "sha512-DzFJ0wx5B8rZ7Kxy8EIz7LIHYf8mDt8Bd6WEiEO2r9NVihgiFHNa4a0k/s3SoY2vVESkJgpUqqoizVIAEDDsOg==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
-        "@fluentui/react-label": "^9.3.13",
-        "@fluentui/react-popover": "^9.13.0",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
+        "@fluentui/react-label": "^9.3.14",
+        "@fluentui/react-popover": "^9.13.1",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -1769,13 +1769,13 @@
       }
     },
     "node_modules/@fluentui/react-input": {
-      "version": "9.7.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.7.13.tgz",
-      "integrity": "sha512-klhtp4D85Qt8mCGc3Z7kAAAM2mKrpzXiE/I2sCQDFxKlFvwl8Sf4CYnodbca4ywlLI/2nfDK7co7M15rGSIl6A==",
+      "version": "9.7.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.7.14.tgz",
+      "integrity": "sha512-VFNXDSxO/LdEi5wKd+zCLRRtNelGsvaJR4muAm7OJN56GmF+/3Jtq0dKlqkKosHta+zuXGWvGUgSH8fYfy64sQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.4.13",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-field": "^9.4.14",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -1790,14 +1790,13 @@
       }
     },
     "node_modules/@fluentui/react-jsx-runtime": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.3.5.tgz",
-      "integrity": "sha512-Zrgz35HaG1ZHAV8tvUyxHJ6nOcVWfE1iqJ86WGSns4KChda6WfSZeTap+b7tjPiAyOAcH8KCBxqobLybqExMqA==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.0.tgz",
+      "integrity": "sha512-qkY2XPSs1bGTLebo0a8py0d8/buT0TyZwqN4/sW9oFs9j1w6+HcExJgMDyhEJJSwScVHBJQ6nVT1SlzCf/kpRA==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-utilities": "^9.26.1",
-        "@swc/helpers": "^0.5.1",
-        "react-is": "^17.0.2"
+        "@swc/helpers": "^0.5.1"
       },
       "peerDependencies": {
         "@types/react": ">=16.14.0 <20.0.0",
@@ -1805,12 +1804,12 @@
       }
     },
     "node_modules/@fluentui/react-label": {
-      "version": "9.3.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.3.13.tgz",
-      "integrity": "sha512-nWNPUH766eIUVXRBFPLkvkPA9Ln4IP56J8ocGS62dLB1Wc4ggh1G3UDtp2wMgvqdkE4ngKyfh8ERemg/aJXdFA==",
+      "version": "9.3.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.3.14.tgz",
+      "integrity": "sha512-gLg6Rilh5ZJ7Yj3M2HxhoLSVBnhxnKoTONdYcTZHQvlkXZHhWXWBziU+OEuVRw7IjLm50VcyTZ3rAto4pw6sKw==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -1825,13 +1824,13 @@
       }
     },
     "node_modules/@fluentui/react-link": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.7.2.tgz",
-      "integrity": "sha512-DdK0/stocCPgSzMC2FHVG+x1TL3tYh/xBQAK5N2YWkAqUGuWErKUKHMVvUvwT24erDHyrt3o5Zo1ddv4hninIQ==",
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.7.3.tgz",
+      "integrity": "sha512-hE0/XwUtqk4gdlruQaUlDAZ0VNpCjqWzhljbHYAtVbNXky2WJVV4tSZ7RMJbc6v1242GPnI67zwxaxcCuz/bbw==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -1847,15 +1846,15 @@
       }
     },
     "node_modules/@fluentui/react-list": {
-      "version": "9.6.8",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.6.8.tgz",
-      "integrity": "sha512-/In4nuDTpbsueJGjaakQVCrkd3uVRILaawC4tXLRcEUwvQXmoHRBjQBuDGhqRp0/N1Od/cdh1U5E/a5qaLtf5A==",
+      "version": "9.6.9",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.6.9.tgz",
+      "integrity": "sha512-OorRdpSEXEqwrTjqkKmzJUjofcTDauBNM41aWhE/WjfQZXA1Guu2JzafivQmdxLhBRvVxGBzJ3l5BKo9V/goGA==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-checkbox": "^9.5.13",
+        "@fluentui/react-checkbox": "^9.5.14",
         "@fluentui/react-context-selector": "^9.2.14",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -1871,16 +1870,16 @@
       }
     },
     "node_modules/@fluentui/react-menu": {
-      "version": "9.21.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.21.0.tgz",
-      "integrity": "sha512-q/A3DERyRsPatBZ6C23mH+wh/k9OTTA8tNa7sHjHzMFuUTPR+aluLVAxtj6t6stQ09wpxUFtwYrUMq8WJisAJQ==",
+      "version": "9.21.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.21.1.tgz",
+      "integrity": "sha512-dsIPAoLiTWWau3O68LmC9Odlmxe3kB8Tj2FSnKO+H069aJOO9AFOmetqoS1GWUccctjHCttgYY6MP2+Ay8yh7Q==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.8",
+        "@fluentui/react-aria": "^9.17.9",
         "@fluentui/react-context-selector": "^9.2.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-portal": "^9.8.10",
         "@fluentui/react-positioning": "^9.20.12",
         "@fluentui/react-shared-contexts": "^9.26.1",
@@ -1898,15 +1897,15 @@
       }
     },
     "node_modules/@fluentui/react-message-bar": {
-      "version": "9.6.17",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.6.17.tgz",
-      "integrity": "sha512-Izb0Qqnw5P1WKAXH/kAkZDjyZCnd1FbU8Z5VpTIdftSZr8iqOT00ONCM8edD55pj17tVJKY0OmnBlUL/rfLFrA==",
+      "version": "9.6.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.6.18.tgz",
+      "integrity": "sha512-7DLTQpF+X5lxOqrs6vRflKDQoMA09FINEXNA6jB3UWC5Ol5Zk7U8zNt2ovX50n/99DXTKLPmH/22rjEsokAjjg==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-button": "^9.8.0",
+        "@fluentui/react-button": "^9.8.1",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
-        "@fluentui/react-link": "^9.7.2",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
+        "@fluentui/react-link": "^9.7.3",
         "@fluentui/react-motion": "^9.11.6",
         "@fluentui/react-motion-components-preview": "^0.15.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
@@ -1957,24 +1956,24 @@
       }
     },
     "node_modules/@fluentui/react-nav": {
-      "version": "9.3.17",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.3.17.tgz",
-      "integrity": "sha512-v6ftZxtwn+paTelr0W54OpZ/MOJTFf4fnt6IaYmlmM9ypviLteWclNrhtADR/mAf4gad+lieQrraXtnF5NA6hA==",
+      "version": "9.3.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.3.18.tgz",
+      "integrity": "sha512-vnAwnWPOUWyZPf+p5G0BjhO8NLPDF7NygspvXwPja7YV25Xov1oW6q3ijflc+Xj8wOCuyNcdJreRMdOpTmZj6A==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-aria": "^9.17.8",
-        "@fluentui/react-button": "^9.8.0",
+        "@fluentui/react-aria": "^9.17.9",
+        "@fluentui/react-button": "^9.8.1",
         "@fluentui/react-context-selector": "^9.2.14",
-        "@fluentui/react-divider": "^9.6.0",
-        "@fluentui/react-drawer": "^9.11.2",
+        "@fluentui/react-divider": "^9.6.1",
+        "@fluentui/react-drawer": "^9.11.3",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-motion": "^9.11.6",
         "@fluentui/react-motion-components-preview": "^0.15.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
-        "@fluentui/react-tooltip": "^9.9.0",
+        "@fluentui/react-tooltip": "^9.9.1",
         "@fluentui/react-utilities": "^9.26.1",
         "@griffel/react": "^1.5.32",
         "@swc/helpers": "^0.5.1"
@@ -1987,12 +1986,12 @@
       }
     },
     "node_modules/@fluentui/react-overflow": {
-      "version": "9.6.7",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.6.7.tgz",
-      "integrity": "sha512-vJ1F3TNR8j0V215lhthjwvWQgq5pjpgjIS31z3/L+VeApcWy/BtvMk9420KzpOnKbDxgwy6ZTvXxKbE/OYtngA==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.7.0.tgz",
+      "integrity": "sha512-re98BA4Cic/zcA9nLHm9I5Vwyb+keaPnlqJiUUiq/t95ki5xutT37ozqdbMY8IO3VlkS3o8raMKVn6QIMB5huQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/priority-overflow": "^9.2.1",
+        "@fluentui/priority-overflow": "^9.3.0",
         "@fluentui/react-context-selector": "^9.2.14",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -2007,14 +2006,14 @@
       }
     },
     "node_modules/@fluentui/react-persona": {
-      "version": "9.5.14",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.5.14.tgz",
-      "integrity": "sha512-s4jwCbx7l065q35NigldAbGJ4rEJS6UxigaqsnLaWlXnU17klpIPa/awVutGJi0TFa3vDBC8MD/3k74flBj1bw==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.6.0.tgz",
+      "integrity": "sha512-sTxIFEJcwzHtlPWDUknUFZTo6rvAEa5P4FED886svOcxhMx2HH6sfV4NUzFDgvgZAQI9PAvv8nSlT02m5iyGuQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-avatar": "^9.9.14",
-        "@fluentui/react-badge": "^9.4.13",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-avatar": "^9.10.0",
+        "@fluentui/react-badge": "^9.4.14",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -2029,15 +2028,15 @@
       }
     },
     "node_modules/@fluentui/react-popover": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.13.0.tgz",
-      "integrity": "sha512-zNwpHDtwuDjjpZqg2FqPhNcHgJSWuH6+KUjogbx3GRyKgAwToDzdORKHkWVBtehAJEUu8uoLDoiw+GCeZgyPlg==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.13.1.tgz",
+      "integrity": "sha512-B8ZZ5aYkIj/RM89GtDG06IfjNQJTdSZqXBCcCT6deIACYN/0fBJUMk12AIbeed2+PjkNdfvTbTTGIjKTQ02SEQ==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.8",
+        "@fluentui/react-aria": "^9.17.9",
         "@fluentui/react-context-selector": "^9.2.14",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-portal": "^9.8.10",
         "@fluentui/react-positioning": "^9.20.12",
         "@fluentui/react-shared-contexts": "^9.26.1",
@@ -2109,13 +2108,13 @@
       }
     },
     "node_modules/@fluentui/react-progress": {
-      "version": "9.4.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.4.13.tgz",
-      "integrity": "sha512-FebkTCKOeHoXKhvluGXXx0UCfiOhytN4CGahNlnyERaP1+x+IUWOPnEnWc97C8a5ELdSQ+6u6Wy6con2uIwW3w==",
+      "version": "9.4.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.4.14.tgz",
+      "integrity": "sha512-Zmdb22KPdV1pRAmcjRkAGvoNAGCeSYxqvGWgPn438b9c0jyb4OL/wnLj8vHnpZEN5dXAaw3rc5zrVMZsB/zwFQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.4.13",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-field": "^9.4.14",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -2130,13 +2129,13 @@
       }
     },
     "node_modules/@fluentui/react-provider": {
-      "version": "9.22.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.13.tgz",
-      "integrity": "sha512-ZCH6HqpFGlR6wEeHjJVanJrO23mDJn2+tAkhOmakl01DNwElJH6FoP39Fyd/+k/ArBcp9XtlO4IlpG+xybZXlA==",
+      "version": "9.22.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.14.tgz",
+      "integrity": "sha512-VPVRmQvkbd4++8aZLa/Jf2vl1KVX+tfcWeV40M7HiPhER22LkdzJe2NGLCgnjMKJwtPPLK6FqbJTthmClJIeuw==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -2153,14 +2152,14 @@
       }
     },
     "node_modules/@fluentui/react-radio": {
-      "version": "9.5.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.5.13.tgz",
-      "integrity": "sha512-zU7LXVdrrhzgYzQirexPfgC9d3dkzs5AHlon9/XHHb+X2ULkWp0tvJ8PuDGWqMST7Q930iiwlgrCNaWy+rHvHg==",
+      "version": "9.5.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.5.14.tgz",
+      "integrity": "sha512-ZmSpTZn0/Ko0X4oKhfaeycqHLxkabcoUZ6jk0Xtmi4cfdTUChB9dDsRbd6xVSuMxmkmGe+hYzMrJwhKfRgjlGw==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.4.13",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
-        "@fluentui/react-label": "^9.3.13",
+        "@fluentui/react-field": "^9.4.14",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
+        "@fluentui/react-label": "^9.3.14",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -2176,13 +2175,13 @@
       }
     },
     "node_modules/@fluentui/react-rating": {
-      "version": "9.3.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.3.13.tgz",
-      "integrity": "sha512-3+FlVPXvqaE2TJUujqcZVPrepOvJz+ogTpUY5eYYFjago382wLuuU90KpvdIVigZoIdPpwFT4qLFU5Oa4ZHjZw==",
+      "version": "9.3.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.3.14.tgz",
+      "integrity": "sha512-mN+gCj63xmyqt198JwsTwn8vzjluh1UHFVibEq2TdRzJI0bZG6HF43Je8vRFqq1N2WVAszCwF4bMPEM1iLc11g==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -2198,14 +2197,14 @@
       }
     },
     "node_modules/@fluentui/react-search": {
-      "version": "9.3.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.3.13.tgz",
-      "integrity": "sha512-gMq8iGA5Fd54GgNmUM6IUvCs0Ty4PINIevG+Nl3Lfqv04A9nzHvp45nTpES4pSGyyacXat14dL45nFVA+H0VUA==",
+      "version": "9.3.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.3.14.tgz",
+      "integrity": "sha512-e7oB0x6CqtCtt0ROgAK7KaddkGR2bl4WtL5NA/a7NCtYoTTkU9C4LubjqTtfVBKqMPykLjiOdUZOID8Aq3esfg==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-input": "^9.7.13",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-input": "^9.7.14",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -2220,14 +2219,14 @@
       }
     },
     "node_modules/@fluentui/react-select": {
-      "version": "9.4.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.4.13.tgz",
-      "integrity": "sha512-DKKSMK5v4UN5Hjydvllea9tpT+ebRHUQ8/mODnSDhI2vBmNlsuSveDEU3KRmC6O/WtwREXH6vnr7t3fKE+5DCg==",
+      "version": "9.4.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.4.14.tgz",
+      "integrity": "sha512-wfAxwSDNsbjDn8Qh7jXKZnKb2ljMSI4M+SXg+R1ebqNLh527wtKS13i78toWV6NUKrjG7Ycgq7ZN2/oEXCv8VQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.4.13",
+        "@fluentui/react-field": "^9.4.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -2256,13 +2255,13 @@
       }
     },
     "node_modules/@fluentui/react-skeleton": {
-      "version": "9.4.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.4.13.tgz",
-      "integrity": "sha512-S7n/fdtBXcSNeTTI5VwD7OedMzAruXIHy1/aiSUFMkdzK+BZ2RcDbgW7dXxcTWV617uvE9CagBVkju+XxJHG4g==",
+      "version": "9.4.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.4.14.tgz",
+      "integrity": "sha512-Tem5Mn4n6AgSTw2vCR0qjY88XfDvrlpKwiC7Wlu3LhRoXoDBx+JoRJEwA7eymLUYbZznDjPJV9BhS6tpLEVhdg==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.4.13",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-field": "^9.4.14",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -2277,13 +2276,13 @@
       }
     },
     "node_modules/@fluentui/react-slider": {
-      "version": "9.5.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.5.13.tgz",
-      "integrity": "sha512-4A6Qs4pqCm5ZohuWuXeq9geZQb/lEXyuCFfgzIz0dGHXKSa8zEsjXfXZvQgz6OS/FcSAMm0ETAVtSDvS38BCjg==",
+      "version": "9.5.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.5.14.tgz",
+      "integrity": "sha512-bLlYxAfz5uJsg/1QneE/3PjvKKAT6JCnCszVSxik3Et+kHcEp6p2dnjJcTX6NqlDu2Bz1QGpFEQbO443IknBRQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.4.13",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-field": "^9.4.14",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -2299,15 +2298,15 @@
       }
     },
     "node_modules/@fluentui/react-spinbutton": {
-      "version": "9.5.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.5.13.tgz",
-      "integrity": "sha512-/YC74Ikfp8MtxTmQpwaTCTKBRLzTyLbV3hGrGI23d8w7oRvOoAn3NQMZpNSIEtAS/myU8zJDbQg2RvWJ7uWrIA==",
+      "version": "9.5.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.5.14.tgz",
+      "integrity": "sha512-mXoW0ao7vWUzAq8vDButG4ueyTD3sp7pGPYnDdm/V0LNUib5hBiTKIoEA4q1bFjkGMwkHQvC405uV3hyjAIWWA==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-field": "^9.4.13",
+        "@fluentui/react-field": "^9.4.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -2322,13 +2321,13 @@
       }
     },
     "node_modules/@fluentui/react-spinner": {
-      "version": "9.7.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.7.13.tgz",
-      "integrity": "sha512-+F51WwXVjuc6lvJEz+TLMq2FJ7ttvh3tBNUv/MCFTtq3raJon+bAoM52RxVoLT8PMRtGtYDi0NIsB2F3ULVacA==",
+      "version": "9.7.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.7.14.tgz",
+      "integrity": "sha512-OADtpa6nesZq8ITRWVmtbI4LMdvwBZM9N9IaWJffm9c1EOg52b1ob8p09rQAw8dFfS0vn7C48UPYQseV15T3VA==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.3.5",
-        "@fluentui/react-label": "^9.3.13",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
+        "@fluentui/react-label": "^9.3.14",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -2343,15 +2342,15 @@
       }
     },
     "node_modules/@fluentui/react-swatch-picker": {
-      "version": "9.4.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.4.13.tgz",
-      "integrity": "sha512-JPPhwNQG4lEdWHit2evJmjPqVh9xGveuqEiS/Uovxvp5R4jpEiinRpDCVndqV7fNWzhSjb1BDUbIQsbGVWHuXQ==",
+      "version": "9.4.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.4.14.tgz",
+      "integrity": "sha512-iEnM4knd2JgSQnio4rlniYkcCPAHd08uXEGaQVa64d77clIGaq3VYymbkUvgPnwgCu2S3hRrJaCLmXGQujZQhw==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-context-selector": "^9.2.14",
-        "@fluentui/react-field": "^9.4.13",
+        "@fluentui/react-field": "^9.4.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -2367,15 +2366,15 @@
       }
     },
     "node_modules/@fluentui/react-switch": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.5.2.tgz",
-      "integrity": "sha512-VNnJGBMA+hxv0evjkjehZGXzAFXiKMa/t5MxM1ep3RsqUtL47CXWSDmdG2yUo9eP53LDlv3d0CaFWGdL2WdWcw==",
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.5.3.tgz",
+      "integrity": "sha512-k2mA1uFHboWbTuYF3Jjuyif231SVU3/iy6njYFGO9tJS1WI2CbbblnINpwzsfpiWTAGUzzAAudY6ndvLqS2lsg==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.4.13",
+        "@fluentui/react-field": "^9.4.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
-        "@fluentui/react-label": "^9.3.13",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
+        "@fluentui/react-label": "^9.3.14",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -2391,19 +2390,19 @@
       }
     },
     "node_modules/@fluentui/react-table": {
-      "version": "9.19.7",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.19.7.tgz",
-      "integrity": "sha512-Yv1mR5A5SLO5AAaLDVbg9PzrBYibJR4xjYCYpjX3GG2dkCo2JG9USSNs8sRqHhNcEACRt7SHosZ4ISFCKAwy8g==",
+      "version": "9.19.8",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.19.8.tgz",
+      "integrity": "sha512-rDnPpmwVYNNy7iRMuN5offjmpEQILuUVEXoch0cPhrNCLca+hgSQ97YSJy6/4JmXcK7kQvp+MCJn9HpbJNfwOw==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.8",
-        "@fluentui/react-avatar": "^9.9.14",
-        "@fluentui/react-checkbox": "^9.5.13",
+        "@fluentui/react-aria": "^9.17.9",
+        "@fluentui/react-avatar": "^9.10.0",
+        "@fluentui/react-checkbox": "^9.5.14",
         "@fluentui/react-context-selector": "^9.2.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
-        "@fluentui/react-radio": "^9.5.13",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
+        "@fluentui/react-radio": "^9.5.14",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -2419,13 +2418,13 @@
       }
     },
     "node_modules/@fluentui/react-tabs": {
-      "version": "9.11.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.11.0.tgz",
-      "integrity": "sha512-n5L5InLH/9R6bPnXc6OtKE1Y3SppBxz4zDwwjRR9D+yMWYG7AhAWcJzERPqZHdjmtaE11YTlbJSu5mzpyuQ8GA==",
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.11.1.tgz",
+      "integrity": "sha512-BeSbYJy2kRwYI6tObGw0TQ9lmcfTsfAEGCrzScfnzwzp2/DOXI2w+IPR9G+wBg9iL2eMdZ6kIpgcQ4RGhkWBgQ==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react-context-selector": "^9.2.14",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -2462,23 +2461,23 @@
       }
     },
     "node_modules/@fluentui/react-tag-picker": {
-      "version": "9.7.15",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.7.15.tgz",
-      "integrity": "sha512-YdnufpLBF2b+/GP/tcZP5kXnM0RXUzT42O5aBGSEUOWxg9zuOds5dt7jWON3TCQgL27WwT+EQT2YRllXH4BxlA==",
+      "version": "9.7.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.7.16.tgz",
+      "integrity": "sha512-b0PETuBrEvBqPHjxBCp+DSylY4dMeHChqYOSqLYa8MdsSbp37u8wjqcwhzj7XWYSalb3sFGnH0PWYzoteN3DcQ==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.8",
-        "@fluentui/react-combobox": "^9.16.14",
+        "@fluentui/react-aria": "^9.17.9",
+        "@fluentui/react-combobox": "^9.16.15",
         "@fluentui/react-context-selector": "^9.2.14",
-        "@fluentui/react-field": "^9.4.13",
+        "@fluentui/react-field": "^9.4.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-portal": "^9.8.10",
         "@fluentui/react-positioning": "^9.20.12",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
-        "@fluentui/react-tags": "^9.7.14",
+        "@fluentui/react-tags": "^9.7.15",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
         "@griffel/react": "^1.5.32",
@@ -2492,16 +2491,16 @@
       }
     },
     "node_modules/@fluentui/react-tags": {
-      "version": "9.7.14",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.7.14.tgz",
-      "integrity": "sha512-qdjIF3QSA0JZkeAEsi8D2tl5pBJVjT5b1WA7w0SldenyTVnmRpFhqipEUwc1M4SEwSxZiQhmfhHOG6bdQuPTqg==",
+      "version": "9.7.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.7.15.tgz",
+      "integrity": "sha512-T1imCOoatkqu/sAce36Jiq/LUFmGMEKovyo3yahfiRu9uKRhGOO+uaLOWTg5WeHtXYdA+kLw240sAeo5snjPnA==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.8",
-        "@fluentui/react-avatar": "^9.9.14",
+        "@fluentui/react-aria": "^9.17.9",
+        "@fluentui/react-avatar": "^9.10.0",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -2517,17 +2516,17 @@
       }
     },
     "node_modules/@fluentui/react-teaching-popover": {
-      "version": "9.6.15",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.6.15.tgz",
-      "integrity": "sha512-l455X7DOVovHjXcTSKakCHnIKyE1t2djjn9g4onMMclNSTw9durJiP7NgZjeni7q3H+fdQH8EC8cPo0h3xoFpA==",
+      "version": "9.6.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.6.16.tgz",
+      "integrity": "sha512-IV9nKU0Gd9ZnMHXra3lsz6wAg5E63db2IXnugNB+IxC+1YKMAo0ShCupPua/5pFPRH6ufAMd46ltZLUUPME/MQ==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-aria": "^9.17.8",
-        "@fluentui/react-button": "^9.8.0",
+        "@fluentui/react-aria": "^9.17.9",
+        "@fluentui/react-button": "^9.8.1",
         "@fluentui/react-context-selector": "^9.2.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
-        "@fluentui/react-popover": "^9.13.0",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
+        "@fluentui/react-popover": "^9.13.1",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -2544,12 +2543,12 @@
       }
     },
     "node_modules/@fluentui/react-text": {
-      "version": "9.6.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.13.tgz",
-      "integrity": "sha512-THLXPS5vMx4lU6dZGJw/BvZeaKjOOKUs+z74mBiTPRYlWb94DKYaN2jDMtwVCTxpvIOTz8JJ/pKLJxhG4XWLkw==",
+      "version": "9.6.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.14.tgz",
+      "integrity": "sha512-ZeddqRqK+4sqctMgbUzXPxaGriHoEDY3S5T8BUM6x2Rb7wBA2cQmb/zh6kr820Rs0A8FREn09XZdM40ueOo0pA==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -2564,13 +2563,13 @@
       }
     },
     "node_modules/@fluentui/react-textarea": {
-      "version": "9.6.13",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.6.13.tgz",
-      "integrity": "sha512-+aMK5pmSV7tifI7X7uWAZJmSTsF+omqql1kYymRQnwcTkJLmjUN2cNIBV4nRE35TuKwjlzhvovnHNX+KCXv0PA==",
+      "version": "9.6.14",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.6.14.tgz",
+      "integrity": "sha512-7hO333OdYbvlVHg4PcymtmsVn8dFOGU704bVDzS/AwFV/6k6PliJ74RP1ufeudtQAty9VW2EoJwHCtwGlgputw==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-field": "^9.4.13",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-field": "^9.4.14",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-theme": "^9.2.1",
         "@fluentui/react-utilities": "^9.26.1",
@@ -2595,15 +2594,15 @@
       }
     },
     "node_modules/@fluentui/react-toast": {
-      "version": "9.7.11",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.7.11.tgz",
-      "integrity": "sha512-iHG+ButeEYoZs7Uw5yicImgJHOGe5cud+bLhdRhn/kse+fddi7LE8R18VlM0yCU2fCM1hEj1lK1zKqdemM9kwQ==",
+      "version": "9.7.12",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.7.12.tgz",
+      "integrity": "sha512-lehROila3FzNZihC+BLtqe/c00JHOo53awYY9ejzLpnEwU9u78MYgTm4dFweeFh0CAMiw3yEzYpI6FZhn4B3mg==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.8",
+        "@fluentui/react-aria": "^9.17.9",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-motion": "^9.11.6",
         "@fluentui/react-motion-components-preview": "^0.15.0",
         "@fluentui/react-portal": "^9.8.10",
@@ -2622,16 +2621,16 @@
       }
     },
     "node_modules/@fluentui/react-toolbar": {
-      "version": "9.7.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.7.1.tgz",
-      "integrity": "sha512-fzgW+/1kncItmbLIUJ1vvbmo6ONyK3ExSbayQjs8oAMhfjk9VvW8uRODDY6vfh4yogeKX4rlg1S0aiHOgiNi4w==",
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.7.2.tgz",
+      "integrity": "sha512-zyr89s7W/HcVMNcbZ/u0rU55e3+Zyy2hEVsnf3P6hic7eIEjW5hTDJwdcLfZ6D41KZKzHG17uFKqGPH/0OSCyg==",
       "license": "MIT",
       "dependencies": {
-        "@fluentui/react-button": "^9.8.0",
+        "@fluentui/react-button": "^9.8.1",
         "@fluentui/react-context-selector": "^9.2.14",
-        "@fluentui/react-divider": "^9.6.0",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
-        "@fluentui/react-radio": "^9.5.13",
+        "@fluentui/react-divider": "^9.6.1",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
+        "@fluentui/react-radio": "^9.5.14",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -2647,13 +2646,13 @@
       }
     },
     "node_modules/@fluentui/react-tooltip": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.9.0.tgz",
-      "integrity": "sha512-v7Umx9PvzZ53BEDQmLNysoY+/7NchnsQjUbbWO2EEPWZJp6xKkvDNSrXxm7YzOBorDhNBsIc/FSSdcZcCBqysA==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.9.1.tgz",
+      "integrity": "sha512-iSJfIis9dHHkymkasH/AI5R+2t4wI2ecCoqRwkW5dBAOV8YTWC0vgTHCubfWfTkYt303nqEdteCbGAIEene8hQ==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-portal": "^9.8.10",
         "@fluentui/react-positioning": "^9.20.12",
         "@fluentui/react-shared-contexts": "^9.26.1",
@@ -2671,22 +2670,22 @@
       }
     },
     "node_modules/@fluentui/react-tree": {
-      "version": "9.15.9",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.15.9.tgz",
-      "integrity": "sha512-+WXRFwV5TvjBCVYdghuvA73IBvDhzPyPKZurlfxZbAM4m3rAwsvJfbAKCJEnlferkBFPmskAldWcQWYVfryGSg==",
+      "version": "9.15.10",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.15.10.tgz",
+      "integrity": "sha512-V0q4H7XBmARre7oKPuxGZaFdz4K6ptNmBd4bNRa0geqOsSdNI4XJ8i5tAetDeGd2lS8AlA9D5NyzlBSXvBzazQ==",
       "license": "MIT",
       "dependencies": {
         "@fluentui/keyboard-keys": "^9.0.8",
-        "@fluentui/react-aria": "^9.17.8",
-        "@fluentui/react-avatar": "^9.9.14",
-        "@fluentui/react-button": "^9.8.0",
-        "@fluentui/react-checkbox": "^9.5.13",
+        "@fluentui/react-aria": "^9.17.9",
+        "@fluentui/react-avatar": "^9.10.0",
+        "@fluentui/react-button": "^9.8.1",
+        "@fluentui/react-checkbox": "^9.5.14",
         "@fluentui/react-context-selector": "^9.2.14",
         "@fluentui/react-icons": "^2.0.245",
-        "@fluentui/react-jsx-runtime": "^9.3.5",
+        "@fluentui/react-jsx-runtime": "^9.4.0",
         "@fluentui/react-motion": "^9.11.6",
         "@fluentui/react-motion-components-preview": "^0.15.0",
-        "@fluentui/react-radio": "^9.5.13",
+        "@fluentui/react-radio": "^9.5.14",
         "@fluentui/react-shared-contexts": "^9.26.1",
         "@fluentui/react-tabster": "^9.26.12",
         "@fluentui/react-theme": "^9.2.1",
@@ -12772,9 +12771,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
-      "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
+      "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12788,7 +12787,7 @@
         "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@testing-library/dom/node_modules/aria-query": {
@@ -12859,22 +12858,22 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.5.tgz",
-      "integrity": "sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==",
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
+      "integrity": "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0",
-        "@types/react-dom": "<18.0.0"
+        "@testing-library/dom": "^9.0.0",
+        "@types/react-dom": "^18.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "peerDependencies": {
-        "react": "<18.0.0",
-        "react-dom": "<18.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -13746,9 +13745,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "17.0.67",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.67.tgz",
-      "integrity": "sha512-zE76EIJ0Y58Oy9yDX/9csb/NuKjt0Eq2YgWb/8Wxo91YmuLzzbyiRoaqJE9h8iDlsT7n35GdpoLomHlaB1kFbg==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==",
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -13757,12 +13756,12 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.21.tgz",
-      "integrity": "sha512-3rQEFUNUUz2MYiRwJJj6UekcW7rFLOtmK7ajQP7qJpjNdggInl3I/xM4I3Hq1yYPdCGVMgax1gZsB7BBTtayXg==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-8yQrvS6sMpSwIovhPOwfyNf2Wz6v/B62LFSVYQ85+Rq3tLsBIG7rP5geMxaijTUxSkrO6RzN/IRuIAADYQsleA==",
       "license": "MIT",
       "dependencies": {
-        "@types/react": "^17"
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-router": {
@@ -35307,46 +35306,44 @@
       }
     },
     "node_modules/react": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
-      "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "17.0.1"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-dom/node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-router": {

--- a/package.json
+++ b/package.json
@@ -34,12 +34,32 @@
     "@pnp/sp": "^4.4.1",
     "html2canvas": "^1.4.1",
     "jspdf": "^2.5.2",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "react-router-dom": "^6.22.3",
     "recharts": "^2.12.3",
     "tslib": "^2.6.2",
     "xlsx": "^0.18.5"
+  },
+  "overrides": {
+    "@microsoft/sp-core-library": {
+      "react": "$react",
+      "react-dom": "$react-dom",
+      "@types/react": "$@types/react",
+      "@types/react-dom": "$@types/react-dom"
+    },
+    "@microsoft/sp-webpart-base": {
+      "react": "$react",
+      "react-dom": "$react-dom",
+      "@types/react": "$@types/react",
+      "@types/react-dom": "$@types/react-dom"
+    },
+    "@microsoft/sp-property-pane": {
+      "react": "$react",
+      "react-dom": "$react-dom",
+      "@types/react": "$@types/react",
+      "@types/react-dom": "$@types/react-dom"
+    }
   },
   "devDependencies": {
     "@microsoft/eslint-config-spfx": "1.21.1",
@@ -48,10 +68,10 @@
     "@microsoft/sp-build-web": "1.21.1",
     "@microsoft/sp-module-interfaces": "1.21.1",
     "@testing-library/jest-dom": "^6.4.2",
-    "@testing-library/react": "^12.1.5",
+    "@testing-library/react": "^14.0.0",
     "@types/jest": "^29.5.12",
-    "@types/react": "17.0.67",
-    "@types/react-dom": "17.0.21",
+    "@types/react": "18.2.0",
+    "@types/react-dom": "18.2.0",
     "@types/react-router-dom": "^5.3.3",
     "@types/webpack-env": "^1.18.8",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/src/webparts/hbcProjectControls/HbcProjectControlsWebPart.ts
+++ b/src/webparts/hbcProjectControls/HbcProjectControlsWebPart.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as ReactDom from 'react-dom';
+import { createRoot, Root } from 'react-dom/client';
 import { Version } from '@microsoft/sp-core-library';
 import { BaseClientSideWebPart } from '@microsoft/sp-webpart-base';
 import { IPropertyPaneConfiguration, PropertyPaneTextField } from '@microsoft/sp-property-pane';
@@ -20,6 +20,7 @@ export interface IHbcProjectControlsWebPartProps {
 
 export default class HbcProjectControlsWebPart extends BaseClientSideWebPart<IHbcProjectControlsWebPartProps> {
   private _dataService!: IDataService;
+  private _root: Root | null = null;
 
   protected async onInit(): Promise<void> {
     await super.onInit();
@@ -74,11 +75,15 @@ export default class HbcProjectControlsWebPart extends BaseClientSideWebPart<IHb
       siteUrl: this.context.pageContext.web.absoluteUrl,
     });
 
-    ReactDom.render(element, this.domElement);
+    if (!this._root) {
+      this._root = createRoot(this.domElement);
+    }
+    this._root.render(element);
   }
 
   protected onDispose(): void {
-    ReactDom.unmountComponentAtNode(this.domElement);
+    this._root?.unmount();
+    this._root = null;
   }
 
   protected get dataVersion(): Version {


### PR DESCRIPTION
## Summary
- **React 18.2.0**: Bumped react/react-dom from 17.0.1 → 18.2.0 with npm `overrides` to bypass SPFx 1.21.1 peer dep constraints (`<18.0.0`)
- **createRoot API**: Migrated `HbcProjectControlsWebPart.ts` and `dev/index.tsx` from deprecated `ReactDOM.render()` to React 18 `createRoot()` with proper `Root` lifecycle management
- **Fluent UI v9 theming**: Full `makeStyles` migration for 10 shared components, 30+ theme token overrides, 40+ reusable Griffel classes (prior commit on this branch)
- **SharePoint Data Service**: 4 implementation chunks — Permissions & Security (20), Provisioning & Infrastructure (10), Workflow Definitions (10), Checklists/Matrices/Marketing (22) — totaling 62 new SP implementations (prior commits on this branch)
- **@testing-library/react**: Bumped ^12 → ^14 for React 18 compatibility
- **Zero component/style/service/workflow changes** in the React 18 commit — `tsc --noEmit` passes cleanly

## Test plan
- [ ] `npm install` completes without peer dep errors
- [ ] `npx tsc --noEmit` returns zero errors
- [ ] `npm run dev` — dev server renders at localhost:3000
- [ ] No console warnings about deprecated `ReactDOM.render`
- [ ] Role switcher + navigation still functional
- [ ] SPFx `gulp serve --nobrowser` builds successfully (volta run --node 22.14.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)