### PR TITLE
perf: route-based code splitting (React.lazy + Suspense)

### DIFF
--- a/src/webparts/hbcProjectControls/components/App.tsx
+++ b/src/webparts/hbcProjectControls/components/App.tsx
@@ -6,58 +6,84 @@ import { AppProvider } from './contexts/AppContext';
 import { AppShell } from './layouts/AppShell';
 import { ErrorBoundary } from './shared/ErrorBoundary';
 import { ToastProvider } from './shared/ToastContainer';
+import { PageLoader } from './shared/PageLoader';
 import { IDataService } from '../services/IDataService';
-
-// Hub pages
-import { PipelinePage } from './pages/hub/PipelinePage';
-import { DashboardPage } from './pages/hub/DashboardPage';
-import { LeadDetailPage } from './pages/hub/LeadDetailPage';
-import { LeadFormPage } from './pages/hub/LeadFormPage';
-import { GoNoGoScorecard } from './pages/hub/GoNoGoScorecard';
-import { GoNoGoDetail } from './pages/hub/GoNoGoDetail';
-import { GoNoGoMeetingScheduler } from './pages/hub/GoNoGoMeetingScheduler';
-import { AdminPanel } from './pages/hub/AdminPanel';
-import { MarketingDashboard } from './pages/hub/MarketingDashboard';
-import { JobNumberRequestForm } from './pages/hub/JobNumberRequestForm';
-import { AccountingQueuePage } from './pages/hub/AccountingQueuePage';
-import { ActiveProjectsDashboard } from './pages/hub/ActiveProjectsDashboard';
-import { ComplianceLog } from './pages/hub/ComplianceLog';
-
-// Precon pages
-import { EstimatingDashboard } from './pages/precon/EstimatingDashboard';
-import { PursuitDetail } from './pages/precon/PursuitDetail';
-import { GoNoGoTracker } from './pages/precon/GoNoGoTracker';
-import { EstimatingKickoffList } from './pages/precon/EstimatingKickoffList';
-import { EstimatingKickoffPage } from './pages/precon/EstimatingKickoffPage';
-import { PostBidAutopsyList } from './pages/precon/PostBidAutopsyList';
-import { PostBidAutopsyForm } from './pages/precon/PostBidAutopsyForm';
-
-// Project pages
-import { ProjectDashboard } from './pages/project/ProjectDashboard';
-import { PreconKickoff } from './pages/project/PreconKickoff';
-import { DeliverablesTracker } from './pages/project/DeliverablesTracker';
-import { InterviewPrep } from './pages/project/InterviewPrep';
-import { WinLossRecorder } from './pages/project/WinLossRecorder';
-import { LossAutopsy } from './pages/project/LossAutopsy';
-import { ContractTracking } from './pages/project/ContractTracking';
-import { TurnoverToOps } from './pages/project/TurnoverToOps';
-import { CloseoutChecklist } from './pages/project/CloseoutChecklist';
-import { ProjectStartupChecklist } from './pages/project/ProjectStartupChecklist';
-import { ResponsibilityMatrices } from './pages/project/ResponsibilityMatrices';
-import { ProjectRecord } from './pages/project/ProjectRecord';
-import { RiskCostManagement } from './pages/project/RiskCostManagement';
-import { QualityConcernsTracker } from './pages/project/QualityConcernsTracker';
-import { SafetyConcernsTracker } from './pages/project/SafetyConcernsTracker';
-import { ProjectScheduleCriticalPath } from './pages/project/ProjectScheduleCriticalPath';
-import { SuperintendentPlanPage } from './pages/project/SuperintendentPlanPage';
-import { LessonsLearnedPage } from './pages/project/LessonsLearnedPage';
-import { ProjectManagementPlan } from './pages/project/pmp/ProjectManagementPlan';
-import { MonthlyProjectReview } from './pages/project/MonthlyProjectReview';
-import { BuyoutLogPage } from './pages/project/BuyoutLogPage';
-import { AccessDeniedPage } from './pages/shared/AccessDeniedPage';
 import { ProtectedRoute, ProjectRequiredRoute, FeatureGate } from './guards';
-
 import { PERMISSIONS } from '../utils/permissions';
+
+// ---------------------------------------------------------------------------
+// Helper: wrap React.lazy() for named exports
+// ---------------------------------------------------------------------------
+function lazyNamed<T extends React.ComponentType<Record<string, never>>>(
+  factory: () => Promise<{ [key: string]: T }>
+): React.LazyExoticComponent<T> {
+  return React.lazy(() =>
+    factory().then((mod) => {
+      const key = Object.keys(mod)[0];
+      return { default: mod[key] };
+    })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Lazy page imports — Hub
+// ---------------------------------------------------------------------------
+const DashboardPage = lazyNamed(() => import('./pages/hub/DashboardPage'));
+const PipelinePage = lazyNamed(() => import('./pages/hub/PipelinePage'));
+const MarketingDashboard = lazyNamed(() => import('./pages/hub/MarketingDashboard'));
+const LeadFormPage = lazyNamed(() => import('./pages/hub/LeadFormPage'));
+const LeadDetailPage = lazyNamed(() => import('./pages/hub/LeadDetailPage'));
+const GoNoGoScorecard = lazyNamed(() => import('./pages/hub/GoNoGoScorecard'));
+const GoNoGoDetail = lazyNamed(() => import('./pages/hub/GoNoGoDetail'));
+const GoNoGoMeetingScheduler = lazyNamed(() => import('./pages/hub/GoNoGoMeetingScheduler'));
+const JobNumberRequestForm = lazyNamed(() => import('./pages/hub/JobNumberRequestForm'));
+const AccountingQueuePage = lazyNamed(() => import('./pages/hub/AccountingQueuePage'));
+const ActiveProjectsDashboard = lazyNamed(() => import('./pages/hub/ActiveProjectsDashboard'));
+const ComplianceLog = lazyNamed(() => import('./pages/hub/ComplianceLog'));
+
+// ---------------------------------------------------------------------------
+// Lazy page imports — Admin
+// ---------------------------------------------------------------------------
+const AdminPanel = lazyNamed(() => import('./pages/hub/AdminPanel'));
+
+// ---------------------------------------------------------------------------
+// Lazy page imports — Precon
+// ---------------------------------------------------------------------------
+const EstimatingDashboard = lazyNamed(() => import('./pages/precon/EstimatingDashboard'));
+const PursuitDetail = lazyNamed(() => import('./pages/precon/PursuitDetail'));
+const EstimatingKickoffList = lazyNamed(() => import('./pages/precon/EstimatingKickoffList'));
+const EstimatingKickoffPage = lazyNamed(() => import('./pages/precon/EstimatingKickoffPage'));
+const PostBidAutopsyList = lazyNamed(() => import('./pages/precon/PostBidAutopsyList'));
+const PostBidAutopsyForm = lazyNamed(() => import('./pages/precon/PostBidAutopsyForm'));
+
+// ---------------------------------------------------------------------------
+// Lazy page imports — Project execution
+// ---------------------------------------------------------------------------
+const ProjectDashboard = lazyNamed(() => import('./pages/project/ProjectDashboard'));
+const DeliverablesTracker = lazyNamed(() => import('./pages/project/DeliverablesTracker'));
+const InterviewPrep = lazyNamed(() => import('./pages/project/InterviewPrep'));
+const WinLossRecorder = lazyNamed(() => import('./pages/project/WinLossRecorder'));
+const LossAutopsy = lazyNamed(() => import('./pages/project/LossAutopsy'));
+const ContractTracking = lazyNamed(() => import('./pages/project/ContractTracking'));
+const TurnoverToOps = lazyNamed(() => import('./pages/project/TurnoverToOps'));
+const CloseoutChecklist = lazyNamed(() => import('./pages/project/CloseoutChecklist'));
+const ProjectStartupChecklist = lazyNamed(() => import('./pages/project/ProjectStartupChecklist'));
+const ResponsibilityMatrices = lazyNamed(() => import('./pages/project/ResponsibilityMatrices'));
+const ProjectRecord = lazyNamed(() => import('./pages/project/ProjectRecord'));
+const RiskCostManagement = lazyNamed(() => import('./pages/project/RiskCostManagement'));
+const QualityConcernsTracker = lazyNamed(() => import('./pages/project/QualityConcernsTracker'));
+const SafetyConcernsTracker = lazyNamed(() => import('./pages/project/SafetyConcernsTracker'));
+const ProjectScheduleCriticalPath = lazyNamed(() => import('./pages/project/ProjectScheduleCriticalPath'));
+const SuperintendentPlanPage = lazyNamed(() => import('./pages/project/SuperintendentPlanPage'));
+const LessonsLearnedPage = lazyNamed(() => import('./pages/project/LessonsLearnedPage'));
+const ProjectManagementPlan = lazyNamed(() => import('./pages/project/pmp/ProjectManagementPlan'));
+const MonthlyProjectReview = lazyNamed(() => import('./pages/project/MonthlyProjectReview'));
+const BuyoutLogPage = lazyNamed(() => import('./pages/project/BuyoutLogPage'));
+
+// ---------------------------------------------------------------------------
+// Inline tiny pages — kept in main bundle (no benefit from splitting)
+// ---------------------------------------------------------------------------
+import { AccessDeniedPage } from './pages/shared/AccessDeniedPage';
 
 export interface IAppProps {
   dataService: IDataService;
@@ -72,222 +98,224 @@ const NotFoundPage: React.FC = () => (
 );
 
 const AppRoutes: React.FC = () => (
-  <Routes>
-    {/* Dashboard — universal landing page */}
-    <Route path="/" element={<DashboardPage />} />
+  <React.Suspense fallback={<PageLoader />}>
+    <Routes>
+      {/* Dashboard — universal landing page */}
+      <Route path="/" element={<DashboardPage />} />
 
-    {/* Marketing */}
-    <Route path="/marketing" element={
-      <ProtectedRoute permission={PERMISSIONS.MARKETING_DASHBOARD_VIEW}>
-        <MarketingDashboard />
-      </ProtectedRoute>
-    } />
-
-    {/* Preconstruction */}
-    <Route path="/preconstruction" element={
-      <FeatureGate featureName="EstimatingTracker" fallback={<NotFoundPage />}>
-        <EstimatingDashboard />
-      </FeatureGate>
-    } />
-    <Route path="/preconstruction/pipeline" element={
-      <FeatureGate featureName="PipelineDashboard" fallback={<NotFoundPage />}>
-        <PipelinePage />
-      </FeatureGate>
-    } />
-    <Route path="/preconstruction/pipeline/gonogo" element={
-      <FeatureGate featureName="PipelineDashboard" fallback={<NotFoundPage />}>
-        <PipelinePage />
-      </FeatureGate>
-    } />
-    <Route path="/preconstruction/gonogo" element={
-      <FeatureGate featureName="PipelineDashboard" fallback={<NotFoundPage />}>
-        <PipelinePage />
-      </FeatureGate>
-    } />
-    <Route path="/preconstruction/precon-tracker" element={
-      <FeatureGate featureName="EstimatingTracker" fallback={<NotFoundPage />}>
-        <EstimatingDashboard />
-      </FeatureGate>
-    } />
-    <Route path="/preconstruction/estimate-log" element={
-      <FeatureGate featureName="EstimatingTracker" fallback={<NotFoundPage />}>
-        <EstimatingDashboard />
-      </FeatureGate>
-    } />
-    <Route path="/preconstruction/kickoff-list" element={
-      <ProtectedRoute permission={PERMISSIONS.KICKOFF_VIEW}>
-        <EstimatingKickoffList />
-      </ProtectedRoute>
-    } />
-    <Route path="/preconstruction/autopsy-list" element={
-      <FeatureGate featureName="LossAutopsy" fallback={<NotFoundPage />}>
-        <ProtectedRoute permission={PERMISSIONS.AUTOPSY_VIEW}>
-          <PostBidAutopsyList />
+      {/* Marketing */}
+      <Route path="/marketing" element={
+        <ProtectedRoute permission={PERMISSIONS.MARKETING_DASHBOARD_VIEW}>
+          <MarketingDashboard />
         </ProtectedRoute>
-      </FeatureGate>
-    } />
-    <Route path="/preconstruction/pursuit/:id" element={<PursuitDetail />} />
-    <Route path="/preconstruction/pursuit/:id/kickoff" element={
-      <ProtectedRoute permission={PERMISSIONS.KICKOFF_VIEW}>
-        <EstimatingKickoffPage />
-      </ProtectedRoute>
-    } />
-    <Route path="/preconstruction/pursuit/:id/interview" element={<InterviewPrep />} />
-    <Route path="/preconstruction/pursuit/:id/winloss" element={<WinLossRecorder />} />
-    <Route path="/preconstruction/pursuit/:id/turnover" element={
-      <FeatureGate featureName="TurnoverWorkflow" fallback={<NotFoundPage />}>
-        <TurnoverToOps />
-      </FeatureGate>
-    } />
-    <Route path="/preconstruction/pursuit/:id/autopsy" element={
-      <FeatureGate featureName="LossAutopsy" fallback={<NotFoundPage />}>
-        <LossAutopsy />
-      </FeatureGate>
-    } />
-    <Route path="/preconstruction/pursuit/:id/autopsy-form" element={
-      <FeatureGate featureName="LossAutopsy" fallback={<NotFoundPage />}>
-        <ProtectedRoute permission={PERMISSIONS.AUTOPSY_VIEW}>
-          <PostBidAutopsyForm />
+      } />
+
+      {/* Preconstruction */}
+      <Route path="/preconstruction" element={
+        <FeatureGate featureName="EstimatingTracker" fallback={<NotFoundPage />}>
+          <EstimatingDashboard />
+        </FeatureGate>
+      } />
+      <Route path="/preconstruction/pipeline" element={
+        <FeatureGate featureName="PipelineDashboard" fallback={<NotFoundPage />}>
+          <PipelinePage />
+        </FeatureGate>
+      } />
+      <Route path="/preconstruction/pipeline/gonogo" element={
+        <FeatureGate featureName="PipelineDashboard" fallback={<NotFoundPage />}>
+          <PipelinePage />
+        </FeatureGate>
+      } />
+      <Route path="/preconstruction/gonogo" element={
+        <FeatureGate featureName="PipelineDashboard" fallback={<NotFoundPage />}>
+          <PipelinePage />
+        </FeatureGate>
+      } />
+      <Route path="/preconstruction/precon-tracker" element={
+        <FeatureGate featureName="EstimatingTracker" fallback={<NotFoundPage />}>
+          <EstimatingDashboard />
+        </FeatureGate>
+      } />
+      <Route path="/preconstruction/estimate-log" element={
+        <FeatureGate featureName="EstimatingTracker" fallback={<NotFoundPage />}>
+          <EstimatingDashboard />
+        </FeatureGate>
+      } />
+      <Route path="/preconstruction/kickoff-list" element={
+        <ProtectedRoute permission={PERMISSIONS.KICKOFF_VIEW}>
+          <EstimatingKickoffList />
         </ProtectedRoute>
-      </FeatureGate>
-    } />
-    <Route path="/preconstruction/pursuit/:id/deliverables" element={<DeliverablesTracker />} />
+      } />
+      <Route path="/preconstruction/autopsy-list" element={
+        <FeatureGate featureName="LossAutopsy" fallback={<NotFoundPage />}>
+          <ProtectedRoute permission={PERMISSIONS.AUTOPSY_VIEW}>
+            <PostBidAutopsyList />
+          </ProtectedRoute>
+        </FeatureGate>
+      } />
+      <Route path="/preconstruction/pursuit/:id" element={<PursuitDetail />} />
+      <Route path="/preconstruction/pursuit/:id/kickoff" element={
+        <ProtectedRoute permission={PERMISSIONS.KICKOFF_VIEW}>
+          <EstimatingKickoffPage />
+        </ProtectedRoute>
+      } />
+      <Route path="/preconstruction/pursuit/:id/interview" element={<InterviewPrep />} />
+      <Route path="/preconstruction/pursuit/:id/winloss" element={<WinLossRecorder />} />
+      <Route path="/preconstruction/pursuit/:id/turnover" element={
+        <FeatureGate featureName="TurnoverWorkflow" fallback={<NotFoundPage />}>
+          <TurnoverToOps />
+        </FeatureGate>
+      } />
+      <Route path="/preconstruction/pursuit/:id/autopsy" element={
+        <FeatureGate featureName="LossAutopsy" fallback={<NotFoundPage />}>
+          <LossAutopsy />
+        </FeatureGate>
+      } />
+      <Route path="/preconstruction/pursuit/:id/autopsy-form" element={
+        <FeatureGate featureName="LossAutopsy" fallback={<NotFoundPage />}>
+          <ProtectedRoute permission={PERMISSIONS.AUTOPSY_VIEW}>
+            <PostBidAutopsyForm />
+          </ProtectedRoute>
+        </FeatureGate>
+      } />
+      <Route path="/preconstruction/pursuit/:id/deliverables" element={<DeliverablesTracker />} />
 
-    {/* Lead */}
-    <Route path="/lead/new" element={
-      <FeatureGate featureName="LeadIntake" fallback={<NotFoundPage />}>
-        <LeadFormPage />
-      </FeatureGate>
-    } />
-    <Route path="/lead/:id" element={<LeadDetailPage />} />
-    <Route path="/lead/:id/gonogo" element={
-      <FeatureGate featureName="GoNoGoScorecard" fallback={<NotFoundPage />}>
-        <GoNoGoScorecard />
-      </FeatureGate>
-    } />
-    <Route path="/lead/:id/gonogo/detail" element={
-      <FeatureGate featureName="GoNoGoScorecard" fallback={<NotFoundPage />}>
-        <GoNoGoDetail />
-      </FeatureGate>
-    } />
-    <Route path="/lead/:id/schedule-gonogo" element={
-      <FeatureGate featureName="GoNoGoScorecard" fallback={<NotFoundPage />}>
-        <GoNoGoMeetingScheduler />
-      </FeatureGate>
-    } />
+      {/* Lead */}
+      <Route path="/lead/new" element={
+        <FeatureGate featureName="LeadIntake" fallback={<NotFoundPage />}>
+          <LeadFormPage />
+        </FeatureGate>
+      } />
+      <Route path="/lead/:id" element={<LeadDetailPage />} />
+      <Route path="/lead/:id/gonogo" element={
+        <FeatureGate featureName="GoNoGoScorecard" fallback={<NotFoundPage />}>
+          <GoNoGoScorecard />
+        </FeatureGate>
+      } />
+      <Route path="/lead/:id/gonogo/detail" element={
+        <FeatureGate featureName="GoNoGoScorecard" fallback={<NotFoundPage />}>
+          <GoNoGoDetail />
+        </FeatureGate>
+      } />
+      <Route path="/lead/:id/schedule-gonogo" element={
+        <FeatureGate featureName="GoNoGoScorecard" fallback={<NotFoundPage />}>
+          <GoNoGoMeetingScheduler />
+        </FeatureGate>
+      } />
 
-    {/* Operations */}
-    <Route path="/operations" element={
-      <ProtectedRoute permission={PERMISSIONS.ACTIVE_PROJECTS_VIEW}>
-        <ActiveProjectsDashboard />
-      </ProtectedRoute>
-    } />
-    <Route path="/operations/project" element={
-      <ProjectRequiredRoute><ProjectDashboard /></ProjectRequiredRoute>
-    } />
-    <Route path="/operations/startup-checklist" element={
-      <FeatureGate featureName="ProjectStartup" fallback={<NotFoundPage />}>
-        <ProjectRequiredRoute><ProjectStartupChecklist /></ProjectRequiredRoute>
-      </FeatureGate>
-    } />
-    <Route path="/operations/management-plan" element={
-      <FeatureGate featureName="ProjectManagementPlan" fallback={<NotFoundPage />}>
+      {/* Operations */}
+      <Route path="/operations" element={
+        <ProtectedRoute permission={PERMISSIONS.ACTIVE_PROJECTS_VIEW}>
+          <ActiveProjectsDashboard />
+        </ProtectedRoute>
+      } />
+      <Route path="/operations/project" element={
+        <ProjectRequiredRoute><ProjectDashboard /></ProjectRequiredRoute>
+      } />
+      <Route path="/operations/startup-checklist" element={
+        <FeatureGate featureName="ProjectStartup" fallback={<NotFoundPage />}>
+          <ProjectRequiredRoute><ProjectStartupChecklist /></ProjectRequiredRoute>
+        </FeatureGate>
+      } />
+      <Route path="/operations/management-plan" element={
+        <FeatureGate featureName="ProjectManagementPlan" fallback={<NotFoundPage />}>
+          <ProjectRequiredRoute>
+            <ProtectedRoute permission={PERMISSIONS.PMP_EDIT}>
+              <ProjectManagementPlan />
+            </ProtectedRoute>
+          </ProjectRequiredRoute>
+        </FeatureGate>
+      } />
+      <Route path="/operations/superintendent-plan" element={
+        <ProjectRequiredRoute><SuperintendentPlanPage /></ProjectRequiredRoute>
+      } />
+      <Route path="/operations/responsibility" element={
+        <FeatureGate featureName="ProjectStartup" fallback={<NotFoundPage />}>
+          <ProjectRequiredRoute><ResponsibilityMatrices /></ProjectRequiredRoute>
+        </FeatureGate>
+      } />
+      <Route path="/operations/responsibility/owner-contract" element={
+        <FeatureGate featureName="ProjectStartup" fallback={<NotFoundPage />}>
+          <ProjectRequiredRoute><ResponsibilityMatrices /></ProjectRequiredRoute>
+        </FeatureGate>
+      } />
+      <Route path="/operations/responsibility/sub-contract" element={
+        <FeatureGate featureName="ProjectStartup" fallback={<NotFoundPage />}>
+          <ProjectRequiredRoute><ResponsibilityMatrices /></ProjectRequiredRoute>
+        </FeatureGate>
+      } />
+      <Route path="/operations/closeout-checklist" element={
+        <ProjectRequiredRoute><CloseoutChecklist /></ProjectRequiredRoute>
+      } />
+      <Route path="/operations/buyout-log" element={
         <ProjectRequiredRoute>
-          <ProtectedRoute permission={PERMISSIONS.PMP_EDIT}>
-            <ProjectManagementPlan />
+          <ProtectedRoute permission={PERMISSIONS.BUYOUT_VIEW}>
+            <BuyoutLogPage />
           </ProtectedRoute>
         </ProjectRequiredRoute>
-      </FeatureGate>
-    } />
-    <Route path="/operations/superintendent-plan" element={
-      <ProjectRequiredRoute><SuperintendentPlanPage /></ProjectRequiredRoute>
-    } />
-    <Route path="/operations/responsibility" element={
-      <FeatureGate featureName="ProjectStartup" fallback={<NotFoundPage />}>
-        <ProjectRequiredRoute><ResponsibilityMatrices /></ProjectRequiredRoute>
-      </FeatureGate>
-    } />
-    <Route path="/operations/responsibility/owner-contract" element={
-      <FeatureGate featureName="ProjectStartup" fallback={<NotFoundPage />}>
-        <ProjectRequiredRoute><ResponsibilityMatrices /></ProjectRequiredRoute>
-      </FeatureGate>
-    } />
-    <Route path="/operations/responsibility/sub-contract" element={
-      <FeatureGate featureName="ProjectStartup" fallback={<NotFoundPage />}>
-        <ProjectRequiredRoute><ResponsibilityMatrices /></ProjectRequiredRoute>
-      </FeatureGate>
-    } />
-    <Route path="/operations/closeout-checklist" element={
-      <ProjectRequiredRoute><CloseoutChecklist /></ProjectRequiredRoute>
-    } />
-    <Route path="/operations/buyout-log" element={
-      <ProjectRequiredRoute>
-        <ProtectedRoute permission={PERMISSIONS.BUYOUT_VIEW}>
-          <BuyoutLogPage />
+      } />
+      <Route path="/operations/contract-tracking" element={
+        <ProjectRequiredRoute><ContractTracking /></ProjectRequiredRoute>
+      } />
+      <Route path="/operations/compliance-log" element={
+        <ProtectedRoute permission={PERMISSIONS.COMPLIANCE_LOG_VIEW}>
+          <ComplianceLog />
         </ProtectedRoute>
-      </ProjectRequiredRoute>
-    } />
-    <Route path="/operations/contract-tracking" element={
-      <ProjectRequiredRoute><ContractTracking /></ProjectRequiredRoute>
-    } />
-    <Route path="/operations/compliance-log" element={
-      <ProtectedRoute permission={PERMISSIONS.COMPLIANCE_LOG_VIEW}>
-        <ComplianceLog />
-      </ProtectedRoute>
-    } />
-    <Route path="/operations/risk-cost" element={
-      <ProjectRequiredRoute>
-        <ProtectedRoute permission={PERMISSIONS.RISK_EDIT}>
-          <RiskCostManagement />
+      } />
+      <Route path="/operations/risk-cost" element={
+        <ProjectRequiredRoute>
+          <ProtectedRoute permission={PERMISSIONS.RISK_EDIT}>
+            <RiskCostManagement />
+          </ProtectedRoute>
+        </ProjectRequiredRoute>
+      } />
+      <Route path="/operations/schedule" element={
+        <ProjectRequiredRoute><ProjectScheduleCriticalPath /></ProjectRequiredRoute>
+      } />
+      <Route path="/operations/quality-concerns" element={
+        <ProjectRequiredRoute><QualityConcernsTracker /></ProjectRequiredRoute>
+      } />
+      <Route path="/operations/safety-concerns" element={
+        <ProjectRequiredRoute><SafetyConcernsTracker /></ProjectRequiredRoute>
+      } />
+      <Route path="/operations/monthly-review" element={
+        <FeatureGate featureName="MonthlyProjectReview" fallback={<NotFoundPage />}>
+          <ProjectRequiredRoute><MonthlyProjectReview /></ProjectRequiredRoute>
+        </FeatureGate>
+      } />
+      <Route path="/operations/project-record" element={
+        <ProjectRequiredRoute><ProjectRecord /></ProjectRequiredRoute>
+      } />
+      <Route path="/operations/lessons-learned" element={
+        <ProjectRequiredRoute><LessonsLearnedPage /></ProjectRequiredRoute>
+      } />
+      <Route path="/operations/gonogo" element={
+        <ProjectRequiredRoute><GoNoGoScorecard /></ProjectRequiredRoute>
+      } />
+
+      {/* Job Request */}
+      <Route path="/job-request" element={<JobNumberRequestForm />} />
+      <Route path="/job-request/:leadId" element={<JobNumberRequestForm />} />
+
+      {/* Accounting */}
+      <Route path="/accounting-queue" element={
+        <ProtectedRoute permission={PERMISSIONS.ACCOUNTING_QUEUE_VIEW}>
+          <AccountingQueuePage />
         </ProtectedRoute>
-      </ProjectRequiredRoute>
-    } />
-    <Route path="/operations/schedule" element={
-      <ProjectRequiredRoute><ProjectScheduleCriticalPath /></ProjectRequiredRoute>
-    } />
-    <Route path="/operations/quality-concerns" element={
-      <ProjectRequiredRoute><QualityConcernsTracker /></ProjectRequiredRoute>
-    } />
-    <Route path="/operations/safety-concerns" element={
-      <ProjectRequiredRoute><SafetyConcernsTracker /></ProjectRequiredRoute>
-    } />
-    <Route path="/operations/monthly-review" element={
-      <FeatureGate featureName="MonthlyProjectReview" fallback={<NotFoundPage />}>
-        <ProjectRequiredRoute><MonthlyProjectReview /></ProjectRequiredRoute>
-      </FeatureGate>
-    } />
-    <Route path="/operations/project-record" element={
-      <ProjectRequiredRoute><ProjectRecord /></ProjectRequiredRoute>
-    } />
-    <Route path="/operations/lessons-learned" element={
-      <ProjectRequiredRoute><LessonsLearnedPage /></ProjectRequiredRoute>
-    } />
-    <Route path="/operations/gonogo" element={
-      <ProjectRequiredRoute><GoNoGoScorecard /></ProjectRequiredRoute>
-    } />
+      } />
 
-    {/* Job Request */}
-    <Route path="/job-request" element={<JobNumberRequestForm />} />
-    <Route path="/job-request/:leadId" element={<JobNumberRequestForm />} />
+      {/* Admin */}
+      <Route path="/admin" element={
+        <ProtectedRoute permission={PERMISSIONS.ADMIN_CONFIG}>
+          <AdminPanel />
+        </ProtectedRoute>
+      } />
 
-    {/* Accounting */}
-    <Route path="/accounting-queue" element={
-      <ProtectedRoute permission={PERMISSIONS.ACCOUNTING_QUEUE_VIEW}>
-        <AccountingQueuePage />
-      </ProtectedRoute>
-    } />
-
-    {/* Admin */}
-    <Route path="/admin" element={
-      <ProtectedRoute permission={PERMISSIONS.ADMIN_CONFIG}>
-        <AdminPanel />
-      </ProtectedRoute>
-    } />
-
-    {/* System */}
-    <Route path="/access-denied" element={<AccessDeniedPage />} />
-    <Route path="*" element={<NotFoundPage />} />
-  </Routes>
+      {/* System */}
+      <Route path="/access-denied" element={<AccessDeniedPage />} />
+      <Route path="*" element={<NotFoundPage />} />
+    </Routes>
+  </React.Suspense>
 );
 
 export const App: React.FC<IAppProps> = ({ dataService, siteUrl }) => {

--- a/src/webparts/hbcProjectControls/components/shared/PageLoader.tsx
+++ b/src/webparts/hbcProjectControls/components/shared/PageLoader.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { Spinner, makeStyles, shorthands, tokens } from '@fluentui/react-components';
+import { SPACING } from '../../theme/tokens';
+
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: '300px',
+    ...shorthands.padding(SPACING.xxl),
+    ...shorthands.gap(SPACING.md),
+  },
+  label: {
+    fontSize: '14px',
+    color: tokens.colorNeutralForeground3,
+  },
+});
+
+/**
+ * Full-page loading fallback for React.lazy() Suspense boundaries.
+ * Centered spinner matching HBC theme. Used as the Suspense fallback
+ * for all lazy-loaded route chunks.
+ */
+export const PageLoader: React.FC = () => {
+  const styles = useStyles();
+  return (
+    <div className={styles.container}>
+      <Spinner size="large" />
+      <span className={styles.label}>Loading page...</span>
+    </div>
+  );
+};

--- a/src/webparts/hbcProjectControls/components/shared/index.ts
+++ b/src/webparts/hbcProjectControls/components/shared/index.ts
@@ -34,3 +34,4 @@ export { ActivityTimeline } from './ActivityTimeline';
 export type { ITimelineEntry } from './ActivityTimeline';
 export { ToolPermissionMatrix } from './ToolPermissionMatrix';
 export { GranularFlagEditor } from './GranularFlagEditor';
+export { PageLoader } from './PageLoader';


### PR DESCRIPTION
## Summary
- Replace 40 static page imports in App.tsx with `React.lazy()` via `lazyNamed()` helper for named-export modules
- Single `<React.Suspense>` boundary wraps `<Routes>` with themed `<PageLoader />` fallback (centered Fluent Spinner)
- Shell stays in main bundle: FluentProvider, AppProvider, HashRouter, AppShell, NavigationSidebar, ErrorBoundary, ToastProvider, all guards, AccessDeniedPage, NotFoundPage
- Removes 2 dead imports (`GoNoGoTracker`, `PreconKickoff` — imported but never routed)
- Zero route guard, data service, model, or styling changes
- `tsc --noEmit` passes cleanly

## Files changed
| File | Change |
|------|--------|
| `App.tsx` | 40 static → lazy imports, +Suspense, +`lazyNamed()` helper |
| `shared/PageLoader.tsx` | New — Suspense fallback component |
| `shared/index.ts` | +PageLoader export |
| `CLAUDE.md` | §1, §2, §3, §5, §15, §16 updates |

## Test plan
- [ ] `npx tsc --noEmit` — zero errors
- [ ] `npm run dev` — dev server renders at localhost:3000
- [ ] Navigate between routes — PageLoader spinner appears briefly on first load of each chunk
- [ ] Sidebar/header remain visible during chunk loading (Suspense is inside AppShell)
- [ ] All route guards (ProtectedRoute, ProjectRequiredRoute, FeatureGate) still function correctly
- [ ] /access-denied and 404 pages load instantly (not lazy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)