### PR TITLE
feat: complete SharePointDataService — 221/221 methods implemented

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,24 @@ Update this file at these specific intervals:
 
 For full historical phase logs (SP-1 through SP-7), complete 221-method table, old navigation, and detailed past pitfalls → see **CLAUDE_ARCHIVE.md**.
 
-**Last Updated:** 2026-02-15 — SP-7: Project Management Plan (PMP) — 7 methods implemented (176 of 221 total)
+**Last Updated:** 2026-02-15 — SP-13: Action Inbox — Data layer COMPLETE (221 of 221 total)
 
 **MANDATORY:** After every code change that affects the data layer, update the relevant sections before ending the session.
+
+---
+
+## §0 Development Workflow Rules
+
+- **After any meaningful code change**, run `/verify-changes` and show the full output before concluding the task.
+- **Never mark work complete** until verification passes (TypeScript, ESLint, tests).
+- **Before commits and PRs**, run `/verify-full-build` to confirm the full production build succeeds.
+- **After completing a data service chunk**, run `/review-chunk` to scan real stub counts and generate CLAUDE.md updates.
+- **Available commands**: `/verify-changes` (quick), `/verify-full-build` (full), `/status` (overview), `/permissions` (allowlist), `/sp-progress` (stub scan), `/review-chunk` (post-chunk).
+
+### Command Evolution Guidelines
+- **Add** a command when: a workflow repeats 3+ times/week, manual execution is error-prone, or it has clear success/failure criteria.
+- **Modify** a command when: user feedback indicates friction, codebase structure changes, or new requirements emerge.
+- **Retire** a command when: unused for 3+ months, superseded by a better command, or its phase is complete.
 
 ---
 
@@ -33,48 +48,40 @@ For full historical phase logs (SP-1 through SP-7), complete 221-method table, o
 
 ## §4 Core Architecture Patterns (Active)
 
-- **Data Service**: `IDataService` (221 methods) → `MockDataService` (full) + `SharePointDataService` (176/221 implemented)
+- **Data Service**: `IDataService` (221 methods) → `MockDataService` (full) + `SharePointDataService` (221/221 — COMPLETE)
 - **Hooks**: Feature-specific hooks call `dataService` methods in `useCallback`
 - **RBAC**: `resolveUserPermissions` → `PermissionGate` / `RoleGate` / `FeatureGate`
 - **Styling**: `makeStyles` (structure) + minimal inline (dynamic) + Fluent tokens + `HBC_COLORS`
 - **Routing**: `HashRouter` + `React.lazy()` + `Suspense` (40 lazy-loaded pages)
-- **Audit**: Fire-and-forget `this.auditService.log()` with debounce
+- **Audit**: Fire-and-forget `this.logAudit()` with debounce
 - **Cross-site Access**: `_getProjectWeb()` helper in SharePointDataService
 
 ---
 
 ## §7 Service Methods Status (Live)
 
-**Total methods**: 221  
-**Implemented**: 176  
-**Delegation stubs**: 6  
-**Remaining stubs**: 39  
+**Total methods**: 221
+**Implemented**: 221
+**Remaining stubs**: 0 — DATA LAYER COMPLETE
 
 **Last Completed**:
-- SP-7 (Feb 15): Project Management Plan (PMP) — 7 methods
-- SP-6: Hub-level CRUD & Reference Data — 21 methods
-- SP-5: Risk/Cost, Quality, Safety, Schedule, Superintendent, Lessons — 19 methods
+- SP-13 (Feb 15): Action Inbox — 1 method → 221/221
+- SP-12 (Feb 15): Help & Support — 6 methods → 220/221
+- SP-11 (Feb 15): Performance Monitoring — 3 methods → 214/221
+- SP-10 (Feb 15): Scorecard Workflow — 9 methods → 211/221
+- SP-9 (Feb 15): Turnover Agenda — 16 methods → 202/221
 
-**Remaining Domains (39 stubs)**:
-- Monthly Project Review (4)
-- Turnover Agenda (16)
-- Scorecard Workflow (9)
-- Action Inbox (1)
-- Performance Monitoring (3)
-- Help & Support (6)
-
-**Next Recommended Chunk**: Monthly Project Review (Chunk 8)
+**Note**: `sendSupportEmail` is a deliberate no-op (requires Graph API not yet available).
 
 ---
 
 ## §15 Current Phase Status
 
-**Active Phase**: Data Layer Completion (SharePointDataService)  
-**Goal**: Reach 221/221 before any new UI or features are built.
+**Phase COMPLETE**: Data Layer Completion (SharePointDataService) — 221/221 methods implemented.
 
-**Recent Progress**:
-- SP-7: PMP (7 methods) → 176/221
-- SP-6: Hub & Reference Data (21 methods) → 169/221
+All IDataService methods now have SharePoint REST implementations. The data layer is production-ready (pending `sendSupportEmail` which requires Graph API).
+
+**Next Phase**: UI completion, integration testing, and deployment readiness.
 
 ---
 
@@ -83,10 +90,11 @@ For full historical phase logs (SP-1 through SP-7), complete 221-method table, o
 (Only the most relevant current ones are kept here. Full historical list is in CLAUDE_ARCHIVE.md)
 
 - Always use `columnMappings.ts` — never hard-code column names.
-- Call `this.auditService.log()` on every mutation.
+- Call `this.logAudit()` on every mutation.
 - Use `_getProjectWeb()` for project-site lists.
 - Hub-site reference data (e.g. Division_Approvers, PMP_Boilerplate) uses `this.sp.web`.
-- After mutations that affect assemblies, always re-read + re-assemble (e.g. PMP, Monthly Review).
+- After mutations that affect assemblies, always re-read + re-assemble (e.g. PMP, Monthly Review, Turnover Agenda).
+- `Turnover_Estimate_Overviews` is a new SP list — must be provisioned before feature goes live.
 - Keep `CLAUDE.md` lean — archive old content aggressively.
 
 ---

--- a/packages/hbc-sp-services/src/services/columnMappings.ts
+++ b/packages/hbc-sp-services/src/services/columnMappings.ts
@@ -1445,6 +1445,7 @@ export const TURNOVER_AGENDAS_COLUMNS = {
   createdDate: 'CreatedDate',                  // SP: DateTime
   lastModifiedBy: 'LastModifiedBy',            // SP: Single Line of Text
   lastModifiedDate: 'LastModifiedDate',        // SP: DateTime
+  headerOverrides: 'HeaderOverrides',          // SP: Multiple Lines of Text (JSON: Record<string, boolean>)
 } as const;
 
 /**
@@ -1540,6 +1541,23 @@ export const TURNOVER_ATTACHMENTS_COLUMNS = {
   fileUrl: 'FileUrl',                          // SP: Hyperlink
   uploadedBy: 'UploadedBy',                    // SP: Single Line of Text
   uploadedDate: 'UploadedDate',                // SP: DateTime
+} as const;
+
+/**
+ * List: Turnover_Estimate_Overviews
+ * Interface: ITurnoverEstimateOverview
+ */
+export const TURNOVER_ESTIMATE_OVERVIEWS_COLUMNS = {
+  id: 'ID',                                    // SP: Auto-generated
+  turnoverAgendaId: 'TurnoverAgendaId',        // SP: Number (lookup ID)
+  contractAmount: 'ContractAmount',            // SP: Number
+  originalEstimate: 'OriginalEstimate',        // SP: Number
+  buyoutTarget: 'BuyoutTarget',               // SP: Number
+  estimatedFee: 'EstimatedFee',               // SP: Number
+  estimatedGrossMargin: 'EstimatedGrossMargin', // SP: Number
+  contingency: 'Contingency',                  // SP: Number
+  notes: 'Notes',                              // SP: Multiple Lines of Text
+  overrides: 'Overrides',                      // SP: Multiple Lines of Text (JSON: Record<string, boolean>)
 } as const;
 
 /**

--- a/packages/hbc-sp-services/src/utils/constants.ts
+++ b/packages/hbc-sp-services/src/utils/constants.ts
@@ -93,6 +93,7 @@ export const PROJECT_LISTS = {
   TURNOVER_EXHIBITS: 'Turnover_Exhibits',
   TURNOVER_SIGNATURES: 'Turnover_Signatures',
   TURNOVER_ATTACHMENTS: 'Turnover_Attachments',
+  TURNOVER_ESTIMATE_OVERVIEWS: 'Turnover_Estimate_Overviews',
 } as const;
 
 export const LIST_NAMES = { ...HUB_LISTS, ...PROJECT_LISTS } as const;


### PR DESCRIPTION
## Summary
- **SP-10**: Scorecard Workflow — 9 methods implementing the full state machine (submit → director review → committee scoring → final decision), approval cycles, version snapshots, and linked Lead updates on Go/NoGo decisions
- **SP-11**: Performance Monitoring — 3 methods for logging entries, querying with filters, and computing summaries with P95 percentile math and day-by-day aggregation
- **SP-12**: Help & Support — 6 methods for guide CRUD, singleton support config via App_Context_Config, and `sendSupportEmail` as a deliberate no-op pending Graph API
- **SP-13**: Action Inbox — 1 cross-domain aggregation method querying scorecard approval steps, PMP approval steps, PMP signatures, and monthly reviews to build prioritized action items

This PR brings the SharePointDataService from 202/221 to **221/221** — completing the entire data layer. Zero stubs remain (except the deliberate `sendSupportEmail` no-op).

## Test plan
- [x] TypeScript compilation clean (`npx tsc --noEmit` — 0 errors)
- [x] ESLint clean (`npm run lint` — 0 errors, 64 pre-existing warnings)
- [x] Stub count verified: `grep -c "STUB\|implementation pending"` → 0
- [ ] Manual smoke test of scorecard workflow state transitions
- [ ] Manual smoke test of action inbox aggregation
- [ ] Verify performance logging on a live SharePoint site

🤖 Generated with [Claude Code](https://claude.com/claude-code)