### PR TITLE
feat: provisioning ops, caching, perf instrumentation & 148 new tests

### DIFF
--- a/packages/hbc-sp-services/src/services/__tests__/MockDataService.buyout.test.ts
+++ b/packages/hbc-sp-services/src/services/__tests__/MockDataService.buyout.test.ts
@@ -1,0 +1,499 @@
+import { MockDataService } from '../MockDataService';
+import { IBuyoutEntry } from '../../models/IBuyoutEntry';
+import { ICommitmentApproval } from '../../models/ICommitmentApproval';
+
+describe('MockDataService — Buyout Schedule & Commitments', () => {
+  let ds: MockDataService;
+
+  beforeEach(() => {
+    ds = new MockDataService();
+  });
+
+  // ─── getBuyoutEntries ──────────────────────────────────────────────
+
+  describe('getBuyoutEntries', () => {
+    it('returns 15 entries for project 25-042-01', async () => {
+      const entries = await ds.getBuyoutEntries('25-042-01');
+      expect(entries).toHaveLength(15);
+    });
+
+    it('returns empty array for unknown project code', async () => {
+      const entries = await ds.getBuyoutEntries('BOGUS-99');
+      expect(entries).toEqual([]);
+    });
+
+    it('results are sorted by divisionCode ascending', async () => {
+      const entries = await ds.getBuyoutEntries('25-042-01');
+      const codes = entries.map(e => e.divisionCode);
+      expect(codes).toEqual([...codes].sort());
+    });
+
+    it('subcontractor entries include enriched e-verify data', async () => {
+      const entries = await ds.getBuyoutEntries('25-042-01');
+      const withSub = entries.filter(e => !!e.subcontractorName);
+      expect(withSub.length).toBe(7);
+      for (const e of withSub) {
+        expect(e.eVerifyStatus).toBeDefined();
+        expect(e.eVerifyContractNumber).toBeDefined();
+        expect(e.qScore).toBeDefined();
+        expect(e.compassPreQualStatus).toBeDefined();
+      }
+    });
+
+    it('entries without subcontractors have no e-verify enrichment', async () => {
+      const entries = await ds.getBuyoutEntries('25-042-01');
+      const withoutSub = entries.filter(e => !e.subcontractorName);
+      expect(withoutSub.length).toBe(8);
+      for (const e of withoutSub) {
+        expect(e.eVerifyContractNumber).toBeUndefined();
+      }
+    });
+  });
+
+  // ─── initializeBuyoutLog ───────────────────────────────────────────
+
+  describe('initializeBuyoutLog', () => {
+    it('returns existing entries when project already has data', async () => {
+      const entries = await ds.initializeBuyoutLog('25-042-01');
+      expect(entries).toHaveLength(15); // existing mock data
+    });
+
+    it('creates 14 standard divisions for new project code', async () => {
+      const entries = await ds.initializeBuyoutLog('NEW-PROJECT');
+      expect(entries).toHaveLength(14);
+      expect(entries.every(e => e.isStandard)).toBe(true);
+    });
+
+    it('new entries have correct defaults', async () => {
+      const entries = await ds.initializeBuyoutLog('NEW-PROJECT');
+      for (const e of entries) {
+        expect(e.commitmentStatus).toBe('Budgeted');
+        expect(e.status).toBe('Not Started');
+        expect(e.originalBudget).toBe(0);
+        expect(e.totalBudget).toBe(0);
+        expect(e.waiverRequired).toBe(false);
+        expect(e.approvalHistory).toEqual([]);
+      }
+    });
+
+    it('new entries persist and are retrievable via getBuyoutEntries', async () => {
+      await ds.initializeBuyoutLog('NEW-PROJECT');
+      const entries = await ds.getBuyoutEntries('NEW-PROJECT');
+      expect(entries).toHaveLength(14);
+    });
+  });
+
+  // ─── addBuyoutEntry ────────────────────────────────────────────────
+
+  describe('addBuyoutEntry', () => {
+    it('creates entry with auto-generated id and timestamps', async () => {
+      const before = new Date().toISOString();
+      const entry = await ds.addBuyoutEntry('25-042-01', {
+        divisionCode: '99-100',
+        divisionDescription: 'Test Division',
+        originalBudget: 50000,
+      });
+      expect(entry.id).toBeGreaterThan(0);
+      expect(entry.projectCode).toBe('25-042-01');
+      expect(entry.createdDate >= before).toBe(true);
+      expect(entry.modifiedDate >= before).toBe(true);
+    });
+
+    it('calculates totalBudget = originalBudget + estimatedTax', async () => {
+      const entry = await ds.addBuyoutEntry('25-042-01', {
+        divisionCode: '99-200',
+        divisionDescription: 'Test',
+        originalBudget: 100000,
+        estimatedTax: 7500,
+      });
+      expect(entry.totalBudget).toBe(107500);
+    });
+
+    it('calculates overUnder when contractValue is provided', async () => {
+      const entry = await ds.addBuyoutEntry('25-042-01', {
+        divisionCode: '99-300',
+        divisionDescription: 'Test',
+        originalBudget: 100000,
+        estimatedTax: 5000,
+        contractValue: 95000,
+      });
+      // overUnder = totalBudget - contractValue = 105000 - 95000
+      expect(entry.overUnder).toBe(10000);
+    });
+
+    it('added entry appears in getBuyoutEntries', async () => {
+      const entry = await ds.addBuyoutEntry('25-042-01', {
+        divisionCode: '99-400',
+        divisionDescription: 'Added Test',
+      });
+      const all = await ds.getBuyoutEntries('25-042-01');
+      const found = all.find(e => e.id === entry.id);
+      expect(found).toBeDefined();
+      expect(found!.divisionDescription).toBe('Added Test');
+    });
+  });
+
+  // ─── updateBuyoutEntry ─────────────────────────────────────────────
+
+  describe('updateBuyoutEntry', () => {
+    it('updates fields and sets modifiedDate', async () => {
+      const before = new Date().toISOString();
+      const updated = await ds.updateBuyoutEntry('25-042-01', 501, {
+        notes: 'Updated note',
+      });
+      expect(updated.notes).toBe('Updated note');
+      expect(updated.modifiedDate >= before).toBe(true);
+    });
+
+    it('recalculates totalBudget when originalBudget changes', async () => {
+      const original = (await ds.getBuyoutEntries('25-042-01')).find(e => e.id === 501)!;
+      const updated = await ds.updateBuyoutEntry('25-042-01', 501, {
+        originalBudget: 60000,
+      });
+      expect(updated.totalBudget).toBe(60000 + updated.estimatedTax);
+    });
+
+    it('recalculates overUnder when contractValue changes', async () => {
+      await ds.updateBuyoutEntry('25-042-01', 505, {
+        originalBudget: 195000,
+        contractValue: 180000,
+      });
+      const entries = await ds.getBuyoutEntries('25-042-01');
+      const entry = entries.find(e => e.id === 505)!;
+      expect(entry.overUnder).toBe(entry.totalBudget - 180000);
+    });
+
+    it('throws for non-existent entry', async () => {
+      await expect(
+        ds.updateBuyoutEntry('25-042-01', 99999, { notes: 'test' })
+      ).rejects.toThrow();
+    });
+
+    it('persists changes on subsequent read', async () => {
+      await ds.updateBuyoutEntry('25-042-01', 501, {
+        subcontractorName: 'New Sub Co.',
+      });
+      const entries = await ds.getBuyoutEntries('25-042-01');
+      const entry = entries.find(e => e.id === 501)!;
+      expect(entry.subcontractorName).toBe('New Sub Co.');
+    });
+  });
+
+  // ─── removeBuyoutEntry ─────────────────────────────────────────────
+
+  describe('removeBuyoutEntry', () => {
+    it('removes entry from collection', async () => {
+      const before = await ds.getBuyoutEntries('25-042-01');
+      expect(before.find(e => e.id === 515)).toBeDefined();
+
+      await ds.removeBuyoutEntry('25-042-01', 515);
+
+      const after = await ds.getBuyoutEntries('25-042-01');
+      expect(after).toHaveLength(before.length - 1);
+      expect(after.find(e => e.id === 515)).toBeUndefined();
+    });
+
+    it('throws for non-existent entry', async () => {
+      await expect(ds.removeBuyoutEntry('25-042-01', 99999)).rejects.toThrow();
+    });
+
+    it('does not affect other entries', async () => {
+      await ds.removeBuyoutEntry('25-042-01', 515);
+      const entries = await ds.getBuyoutEntries('25-042-01');
+      expect(entries).toHaveLength(14);
+      // Verify other entries still intact
+      expect(entries.find(e => e.id === 501)).toBeDefined();
+      expect(entries.find(e => e.id === 507)).toBeDefined();
+    });
+  });
+
+  // ─── submitCommitmentForApproval ───────────────────────────────────
+
+  describe('submitCommitmentForApproval', () => {
+    it('adds PX approval step to history', async () => {
+      const result = await ds.submitCommitmentForApproval('25-042-01', 503, 'test@hbc.com');
+      expect(result.approvalHistory.length).toBeGreaterThan(0);
+      const lastStep = result.approvalHistory[result.approvalHistory.length - 1];
+      expect(lastStep.step).toBe('PX');
+      expect(lastStep.status).toBe('Pending');
+    });
+
+    it('sets currentApprovalStep to PX', async () => {
+      const result = await ds.submitCommitmentForApproval('25-042-01', 503, 'test@hbc.com');
+      expect(result.currentApprovalStep).toBe('PX');
+    });
+
+    it('updates modifiedDate', async () => {
+      const before = new Date().toISOString();
+      const result = await ds.submitCommitmentForApproval('25-042-01', 503, 'test@hbc.com');
+      expect(result.modifiedDate >= before).toBe(true);
+    });
+
+    it('throws for non-existent entry', async () => {
+      await expect(
+        ds.submitCommitmentForApproval('25-042-01', 99999, 'test@hbc.com')
+      ).rejects.toThrow();
+    });
+
+    it('sets WaiverPending for entry with compliance gaps', async () => {
+      // Entry 502: contractValue=135000 (>=$50k), bondRequired=false → bond waiver triggers
+      const result = await ds.submitCommitmentForApproval('25-042-01', 502, 'test@hbc.com');
+      expect(result.waiverRequired).toBe(true);
+      expect(result.commitmentStatus).toBe('WaiverPending');
+    });
+  });
+
+  // ─── respondToCommitmentApproval ───────────────────────────────────
+
+  describe('respondToCommitmentApproval', () => {
+    it('rejection sets commitmentStatus to Rejected', async () => {
+      await ds.submitCommitmentForApproval('25-042-01', 503, 'test@hbc.com');
+      const result = await ds.respondToCommitmentApproval('25-042-01', 503, false, 'Denied');
+      expect(result.commitmentStatus).toBe('Rejected');
+      expect(result.currentApprovalStep).toBeUndefined();
+    });
+
+    it('throws when no pending approval step exists', async () => {
+      // Entry 501 is already Committed — no pending step
+      await expect(
+        ds.respondToCommitmentApproval('25-042-01', 501, true, 'approved')
+      ).rejects.toThrow('No pending approval step');
+    });
+
+    it('PX approval on high-value waiver entry escalates to ComplianceReview', async () => {
+      // Create entry with contractValue >= $250k AND compliance gaps (bondRequired=false)
+      const entry = await ds.addBuyoutEntry('25-042-01', {
+        divisionCode: '99-HV1',
+        divisionDescription: 'High Value Waiver Test',
+        originalBudget: 300000,
+        contractValue: 300000,
+        enrolledInSDI: false,
+        bondRequired: false,
+        subcontractorName: 'Big Sub LLC',
+      });
+      await ds.submitCommitmentForApproval('25-042-01', entry.id, 'test@hbc.com');
+      const result = await ds.respondToCommitmentApproval('25-042-01', entry.id, true, 'Looks good');
+      expect(result.commitmentStatus).toBe('ComplianceReview');
+      expect(result.currentApprovalStep).toBe('ComplianceManager');
+      const cmStep = result.approvalHistory.find(a => a.step === 'ComplianceManager');
+      expect(cmStep).toBeDefined();
+      expect(cmStep!.status).toBe('Pending');
+    });
+
+    it('ComplianceManager escalate creates CFO step', async () => {
+      const entry = await ds.addBuyoutEntry('25-042-01', {
+        divisionCode: '99-HV2',
+        divisionDescription: 'CFO Escalation Test',
+        originalBudget: 400000,
+        contractValue: 400000,
+        enrolledInSDI: false,
+        bondRequired: false,
+        subcontractorName: 'Escalate Sub LLC',
+      });
+      await ds.submitCommitmentForApproval('25-042-01', entry.id, 'test@hbc.com');
+      await ds.respondToCommitmentApproval('25-042-01', entry.id, true, 'PX ok');
+      const result = await ds.respondToCommitmentApproval('25-042-01', entry.id, true, 'Escalating', true);
+      expect(result.commitmentStatus).toBe('CFOReview');
+      expect(result.currentApprovalStep).toBe('CFO');
+      const cfoStep = result.approvalHistory.find(a => a.step === 'CFO');
+      expect(cfoStep).toBeDefined();
+      expect(cfoStep!.status).toBe('Pending');
+    });
+
+    it('final CFO approval sets Committed and Executed', async () => {
+      const entry = await ds.addBuyoutEntry('25-042-01', {
+        divisionCode: '99-HV3',
+        divisionDescription: 'Full Escalation Test',
+        originalBudget: 500000,
+        contractValue: 500000,
+        enrolledInSDI: false,
+        bondRequired: false,
+        subcontractorName: 'Full Flow Sub LLC',
+      });
+      await ds.submitCommitmentForApproval('25-042-01', entry.id, 'test@hbc.com');
+      await ds.respondToCommitmentApproval('25-042-01', entry.id, true, 'PX ok');
+      await ds.respondToCommitmentApproval('25-042-01', entry.id, true, 'Escalating', true);
+      const result = await ds.respondToCommitmentApproval('25-042-01', entry.id, true, 'CFO approved');
+      expect(result.commitmentStatus).toBe('Committed');
+      expect(result.status).toBe('Executed');
+      expect(result.currentApprovalStep).toBeUndefined();
+    });
+  });
+
+  // ─── getCommitmentApprovalHistory ──────────────────────────────────
+
+  describe('getCommitmentApprovalHistory', () => {
+    it('returns approval steps after submission', async () => {
+      await ds.submitCommitmentForApproval('25-042-01', 503, 'test@hbc.com');
+      const history = await ds.getCommitmentApprovalHistory('25-042-01', 503);
+      expect(history.length).toBeGreaterThan(0);
+      expect(history[history.length - 1].step).toBe('PX');
+    });
+
+    it('returns copy of history — modifying result does not affect internal state', async () => {
+      await ds.submitCommitmentForApproval('25-042-01', 503, 'test@hbc.com');
+      const history1 = await ds.getCommitmentApprovalHistory('25-042-01', 503);
+      history1.push({ id: 0, buyoutEntryId: 503, projectCode: '25-042-01', step: 'CFO', approverName: 'Fake', approverEmail: 'fake@hbc.com', status: 'Pending' });
+
+      const history2 = await ds.getCommitmentApprovalHistory('25-042-01', 503);
+      expect(history2.length).toBe(history1.length - 1);
+    });
+
+    it('throws for non-existent entry', async () => {
+      await expect(
+        ds.getCommitmentApprovalHistory('25-042-01', 99999)
+      ).rejects.toThrow();
+    });
+  });
+
+  // ─── Commitment workflow integration ───────────────────────────────
+
+  describe('commitment workflow integration', () => {
+    it('full flow: submit → PX approve → Committed (low-value, no waiver)', async () => {
+      // Create a clean entry with low value and full compliance
+      const entry = await ds.addBuyoutEntry('25-042-01', {
+        divisionCode: '99-900',
+        divisionDescription: 'Low Value Test',
+        originalBudget: 30000,
+        contractValue: 28000,
+        enrolledInSDI: true,
+        bondRequired: true,
+        subcontractorName: 'Clean Sub Inc.',
+      });
+
+      const submitted = await ds.submitCommitmentForApproval('25-042-01', entry.id, 'test@hbc.com');
+      expect(submitted.commitmentStatus).toBe('PendingReview');
+      expect(submitted.waiverRequired).toBe(false);
+
+      const approved = await ds.respondToCommitmentApproval('25-042-01', entry.id, true, 'All good');
+      expect(approved.commitmentStatus).toBe('Committed');
+      expect(approved.status).toBe('Executed');
+    });
+
+    it('full flow: submit → PX reject → Rejected', async () => {
+      const entry = await ds.addBuyoutEntry('25-042-01', {
+        divisionCode: '99-901',
+        divisionDescription: 'Reject Test',
+        originalBudget: 30000,
+        contractValue: 28000,
+        enrolledInSDI: true,
+        bondRequired: true,
+        subcontractorName: 'Reject Sub Inc.',
+      });
+
+      await ds.submitCommitmentForApproval('25-042-01', entry.id, 'test@hbc.com');
+      const rejected = await ds.respondToCommitmentApproval('25-042-01', entry.id, false, 'Not acceptable');
+      expect(rejected.commitmentStatus).toBe('Rejected');
+
+      // Verify the rejection is recorded in history
+      const history = await ds.getCommitmentApprovalHistory('25-042-01', entry.id);
+      const rejectedStep = history.find(a => a.status === 'Rejected');
+      expect(rejectedStep).toBeDefined();
+      expect(rejectedStep!.comment).toBe('Not acceptable');
+    });
+
+    it('full flow: submit → PX → ComplianceReview → approve → Committed (high-value waiver)', async () => {
+      // Create high-value entry with compliance gaps → waiver + escalation
+      const entry = await ds.addBuyoutEntry('25-042-01', {
+        divisionCode: '99-INT',
+        divisionDescription: 'Integration Flow Test',
+        originalBudget: 350000,
+        contractValue: 350000,
+        enrolledInSDI: false,
+        bondRequired: false,
+        subcontractorName: 'Integration Sub LLC',
+      });
+      await ds.submitCommitmentForApproval('25-042-01', entry.id, 'test@hbc.com');
+      await ds.respondToCommitmentApproval('25-042-01', entry.id, true, 'PX approves');
+      const final = await ds.respondToCommitmentApproval('25-042-01', entry.id, true, 'Compliance approves');
+      expect(final.commitmentStatus).toBe('Committed');
+      expect(final.status).toBe('Executed');
+
+      // Full history should have PX (Approved) + ComplianceManager (Approved)
+      const history = await ds.getCommitmentApprovalHistory('25-042-01', entry.id);
+      const pxStep = history.find(a => a.step === 'PX');
+      const cmStep = history.find(a => a.step === 'ComplianceManager');
+      expect(pxStep!.status).toBe('Approved');
+      expect(cmStep!.status).toBe('Approved');
+    });
+  });
+
+  // ─── getComplianceLog ──────────────────────────────────────────────
+
+  describe('getComplianceLog', () => {
+    it('returns entries only for buyouts with subcontractors', async () => {
+      const entries = await ds.getComplianceLog();
+      expect(entries.length).toBe(7); // 7 entries have subcontractors
+      for (const e of entries) {
+        expect(e.subcontractorName).toBeDefined();
+        expect(e.subcontractorName.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('filters by projectCode', async () => {
+      const entries = await ds.getComplianceLog({ projectCode: '25-042-01' });
+      expect(entries.length).toBe(7);
+      expect(entries.every(e => e.projectCode === '25-042-01')).toBe(true);
+
+      const empty = await ds.getComplianceLog({ projectCode: 'BOGUS' });
+      expect(empty).toEqual([]);
+    });
+
+    it('filters by commitmentStatus', async () => {
+      const committed = await ds.getComplianceLog({ commitmentStatus: 'Committed' });
+      expect(committed.length).toBeGreaterThan(0);
+      expect(committed.every(e => e.commitmentStatus === 'Committed')).toBe(true);
+    });
+
+    it('filters by searchQuery (case-insensitive)', async () => {
+      const results = await ds.getComplianceLog({ searchQuery: 'steel' });
+      expect(results.length).toBeGreaterThan(0);
+      const hasMatch = results.some(
+        e => e.subcontractorName.toLowerCase().includes('steel') ||
+             e.divisionDescription.toLowerCase().includes('steel')
+      );
+      expect(hasMatch).toBe(true);
+    });
+
+    it('each entry has computed compliance fields', async () => {
+      const entries = await ds.getComplianceLog();
+      for (const e of entries) {
+        expect(typeof e.riskCompliant).toBe('boolean');
+        expect(typeof e.documentsCompliant).toBe('boolean');
+        expect(typeof e.insuranceCompliant).toBe('boolean');
+        expect(typeof e.eVerifyCompliant).toBe('boolean');
+        expect(typeof e.overallCompliant).toBe('boolean');
+      }
+    });
+  });
+
+  // ─── getComplianceSummary ──────────────────────────────────────────
+
+  describe('getComplianceSummary', () => {
+    it('returns correct totalCommitments count', async () => {
+      const summary = await ds.getComplianceSummary();
+      expect(summary.totalCommitments).toBe(7);
+    });
+
+    it('counts are non-negative and sum is consistent', async () => {
+      const summary = await ds.getComplianceSummary();
+      expect(summary.fullyCompliant).toBeGreaterThanOrEqual(0);
+      expect(summary.eVerifyPending).toBeGreaterThanOrEqual(0);
+      expect(summary.eVerifyOverdue).toBeGreaterThanOrEqual(0);
+      expect(summary.waiversPending).toBeGreaterThanOrEqual(0);
+      expect(summary.documentsMissing).toBeGreaterThanOrEqual(0);
+    });
+
+    it('eVerify counts match compliance log data', async () => {
+      const log = await ds.getComplianceLog();
+      const summary = await ds.getComplianceSummary();
+
+      const pendingStatuses = ['Sent', 'Reminder Sent', 'Not Sent'];
+      const expectedPending = log.filter(e => pendingStatuses.includes(e.eVerifyStatus)).length;
+      const expectedOverdue = log.filter(e => e.eVerifyStatus === 'Overdue').length;
+
+      expect(summary.eVerifyPending).toBe(expectedPending);
+      expect(summary.eVerifyOverdue).toBe(expectedOverdue);
+    });
+  });
+});

--- a/packages/hbc-sp-services/src/services/__tests__/MockDataService.portfolio.test.ts
+++ b/packages/hbc-sp-services/src/services/__tests__/MockDataService.portfolio.test.ts
@@ -1,0 +1,495 @@
+import { MockDataService } from '../MockDataService';
+import { IActiveProject } from '../../models/IActiveProject';
+import { RoleName } from '../../models/enums';
+
+describe('MockDataService — Active Projects Portfolio', () => {
+  let ds: MockDataService;
+
+  beforeEach(() => {
+    ds = new MockDataService();
+  });
+
+  // ─── getActiveProjects ─────────────────────────────────────────────
+
+  describe('getActiveProjects', () => {
+    it('returns all 14 projects when no options', async () => {
+      const projects = await ds.getActiveProjects();
+      expect(projects).toHaveLength(14);
+    });
+
+    it('filters by status Construction → 11', async () => {
+      const projects = await ds.getActiveProjects({ status: 'Construction' });
+      expect(projects).toHaveLength(11);
+      expect(projects.every(p => p.status === 'Construction')).toBe(true);
+    });
+
+    it('filters by status Precon → 2', async () => {
+      const projects = await ds.getActiveProjects({ status: 'Precon' });
+      expect(projects).toHaveLength(2);
+      expect(projects.map(p => p.id).sort()).toEqual([11, 12]);
+    });
+
+    it('filters by sector Residential → 4', async () => {
+      const projects = await ds.getActiveProjects({ sector: 'Residential' });
+      expect(projects).toHaveLength(4);
+      expect(projects.every(p => p.sector === 'Residential')).toBe(true);
+    });
+
+    it('filters by region Miami → 3', async () => {
+      const projects = await ds.getActiveProjects({ region: 'Miami' });
+      expect(projects).toHaveLength(3);
+      expect(projects.map(p => p.id).sort()).toEqual([3, 6, 9]);
+    });
+
+    it('filters by projectExecutive Bob Cashin → 3', async () => {
+      const projects = await ds.getActiveProjects({ projectExecutive: 'Bob Cashin' });
+      expect(projects).toHaveLength(3);
+      expect(projects.map(p => p.id).sort()).toEqual([1, 8, 9]);
+    });
+
+    it('filters by projectManager Bill West → 2', async () => {
+      const projects = await ds.getActiveProjects({ projectManager: 'Bill West' });
+      expect(projects).toHaveLength(2);
+      expect(projects.map(p => p.id).sort((a, b) => a - b)).toEqual([9, 12]);
+    });
+
+    it('applies skip/top pagination', async () => {
+      const page = await ds.getActiveProjects({ skip: 2, top: 3 });
+      expect(page).toHaveLength(3);
+
+      const tail = await ds.getActiveProjects({ skip: 12, top: 5 });
+      expect(tail).toHaveLength(2);
+    });
+
+    it('applies orderBy projectName ascending and descending', async () => {
+      const asc = await ds.getActiveProjects({ orderBy: 'projectName', orderAscending: true });
+      const names = asc.map(p => p.projectName);
+      expect(names).toEqual([...names].sort());
+
+      const desc = await ds.getActiveProjects({ orderBy: 'projectName', orderAscending: false });
+      const descNames = desc.map(p => p.projectName);
+      expect(descNames).toEqual([...descNames].sort().reverse());
+    });
+  });
+
+  // ─── getActiveProjectById ──────────────────────────────────────────
+
+  describe('getActiveProjectById', () => {
+    it('returns project 1 with correct identity fields', async () => {
+      const p = await ds.getActiveProjectById(1);
+      expect(p).not.toBeNull();
+      expect(p!.projectName).toBe('Caretta');
+      expect(p!.jobNumber).toBe('22-140-01');
+      expect(p!.projectCode).toBe('22-140-01');
+      expect(p!.status).toBe('Construction');
+      expect(p!.sector).toBe('Commercial');
+    });
+
+    it('returns null for non-existent id', async () => {
+      const p = await ds.getActiveProjectById(99999);
+      expect(p).toBeNull();
+    });
+
+    it('returned object has nested personnel, financials, schedule, riskMetrics', async () => {
+      const p = await ds.getActiveProjectById(1);
+      expect(p).not.toBeNull();
+      expect(p!.personnel).toBeDefined();
+      expect(p!.personnel.projectExecutive).toBe('Bob Cashin');
+      expect(p!.financials).toBeDefined();
+      expect(p!.financials.originalContract).toBe(45000000);
+      expect(p!.schedule).toBeDefined();
+      expect(p!.schedule.percentComplete).toBe(67);
+      expect(p!.riskMetrics).toBeDefined();
+      expect(p!.riskMetrics.complianceStatus).toBe('Green');
+    });
+  });
+
+  // ─── syncActiveProject ─────────────────────────────────────────────
+
+  describe('syncActiveProject', () => {
+    it('updates lastSyncDate to valid ISO string and returns copy', async () => {
+      const before = new Date().toISOString();
+      const result = await ds.syncActiveProject('22-140-01');
+      expect(result.lastSyncDate).toBeDefined();
+      expect(new Date(result.lastSyncDate!).toISOString()).toBe(result.lastSyncDate);
+      expect(result.lastSyncDate! >= before).toBe(true);
+    });
+
+    it('throws for non-existent projectCode', async () => {
+      await expect(ds.syncActiveProject('BOGUS')).rejects.toThrow();
+    });
+
+    it('returned copy is independent of internal state', async () => {
+      const copy = await ds.syncActiveProject('22-140-01');
+      copy.projectName = 'MUTATED';
+      const fresh = await ds.getActiveProjectById(1);
+      expect(fresh!.projectName).toBe('Caretta');
+    });
+  });
+
+  // ─── updateActiveProject ───────────────────────────────────────────
+
+  describe('updateActiveProject', () => {
+    it('merges partial data and sets lastModified', async () => {
+      const result = await ds.updateActiveProject(1, { statusComments: 'test comment' });
+      expect(result.statusComments).toBe('test comment');
+      expect(result.lastModified).toBeDefined();
+      expect(new Date(result.lastModified!).toISOString()).toBe(result.lastModified);
+    });
+
+    it('persists on subsequent read', async () => {
+      await ds.updateActiveProject(1, { statusComments: 'persisted' });
+      const fresh = await ds.getActiveProjectById(1);
+      expect(fresh!.statusComments).toBe('persisted');
+    });
+
+    it('throws for non-existent id', async () => {
+      await expect(ds.updateActiveProject(99999, {})).rejects.toThrow();
+    });
+
+    it('can update nested fields via full object replacement', async () => {
+      const original = await ds.getActiveProjectById(1);
+      const updatedFinancials = { ...original!.financials, changeOrders: 9999999 };
+      const result = await ds.updateActiveProject(1, { financials: updatedFinancials });
+      expect(result.financials.changeOrders).toBe(9999999);
+    });
+  });
+
+  // ─── getPortfolioSummary ───────────────────────────────────────────
+
+  describe('getPortfolioSummary', () => {
+    it('returns correct projectCount and status/sector counts', async () => {
+      const summary = await ds.getPortfolioSummary();
+      expect(summary.projectCount).toBe(14);
+      expect(summary.projectsByStatus['Construction']).toBe(11);
+      expect(summary.projectsByStatus['Precon']).toBe(2);
+      expect(summary.projectsByStatus['Final Payment']).toBe(1);
+      expect(summary.projectsBySector['Commercial']).toBe(10);
+      expect(summary.projectsBySector['Residential']).toBe(4);
+    });
+
+    it('financial totals are positive and consistent', async () => {
+      const summary = await ds.getPortfolioSummary();
+      expect(summary.totalOriginalContract).toBeGreaterThan(0);
+      expect(summary.totalBillingsToDate).toBeGreaterThan(0);
+      expect(summary.totalOriginalContract).toBeGreaterThan(summary.totalBillingsToDate);
+    });
+
+    it('averageFeePct equals 5.0', async () => {
+      const summary = await ds.getPortfolioSummary();
+      expect(summary.averageFeePct).toBe(5.0);
+    });
+
+    it('applies status filter to reduce set', async () => {
+      const summary = await ds.getPortfolioSummary({ status: 'Precon' });
+      expect(summary.projectCount).toBe(2);
+      expect(summary.projectsByStatus['Precon']).toBe(2);
+      expect(summary.projectsByStatus['Construction']).toBe(0);
+    });
+
+    it('projectsWithAlerts is 0 (no project reaches 15% unbilled threshold)', async () => {
+      const summary = await ds.getPortfolioSummary();
+      // After threshold computation in generateMockActiveProjects, no project's
+      // unbilled/CCV ratio reaches 15%, so all hasUnbilledAlert = false
+      expect(summary.projectsWithAlerts).toBe(0);
+    });
+  });
+
+  // ─── getPersonnelWorkload ──────────────────────────────────────────
+
+  describe('getPersonnelWorkload', () => {
+    it('returns entries for all roles sorted by projectCount desc', async () => {
+      const workload = await ds.getPersonnelWorkload();
+      expect(workload.length).toBeGreaterThan(0);
+      // Verify descending sort
+      for (let i = 1; i < workload.length; i++) {
+        expect(workload[i - 1].projectCount).toBeGreaterThanOrEqual(workload[i].projectCount);
+      }
+      // Should contain PX, PM, and Super roles
+      const roles = new Set(workload.map(w => w.role));
+      expect(roles.has('PX')).toBe(true);
+      expect(roles.has('PM')).toBe(true);
+      expect(roles.has('Super')).toBe(true);
+    });
+
+    it('filters by PX — top entries have projectCount 3', async () => {
+      const workload = await ds.getPersonnelWorkload('PX');
+      expect(workload.every(w => w.role === 'PX')).toBe(true);
+      // Bob Cashin (1,8,9) and Joe Keating (12,13,14) each have 3
+      expect(workload[0].projectCount).toBe(3);
+      expect(workload[1].projectCount).toBe(3);
+    });
+
+    it('filters by PM — Bill West has projectCount 2', async () => {
+      const workload = await ds.getPersonnelWorkload('PM');
+      expect(workload.every(w => w.role === 'PM')).toBe(true);
+      const billWest = workload.find(w => w.name === 'Bill West');
+      expect(billWest).toBeDefined();
+      expect(billWest!.projectCount).toBe(2);
+    });
+  });
+
+  // ─── triggerPortfolioSync ──────────────────────────────────────────
+
+  describe('triggerPortfolioSync', () => {
+    it('resolves without error', async () => {
+      await expect(ds.triggerPortfolioSync()).resolves.toBeUndefined();
+    });
+
+    it('updates lastSyncDate on all 14 projects', async () => {
+      const before = new Date().toISOString();
+      await ds.triggerPortfolioSync();
+      const projects = await ds.getActiveProjects();
+      expect(projects).toHaveLength(14);
+      for (const p of projects) {
+        expect(p.lastSyncDate).toBeDefined();
+        expect(p.lastSyncDate! >= before).toBe(true);
+      }
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Domain 2: Data Mart
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('MockDataService — Data Mart', () => {
+  let ds: MockDataService;
+
+  beforeEach(() => {
+    ds = new MockDataService();
+  });
+
+  // ─── syncToDataMart ────────────────────────────────────────────────
+
+  describe('syncToDataMart', () => {
+    it('returns success:true for known project code', async () => {
+      const result = await ds.syncToDataMart('22-140-01');
+      expect(result.success).toBe(true);
+      expect(result.projectCode).toBe('22-140-01');
+      expect(result.syncedAt).toBeDefined();
+    });
+
+    it('returns success:false with error for unknown project code', async () => {
+      const result = await ds.syncToDataMart('BOGUS-99');
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('creates DataMart record with correct identity fields', async () => {
+      await ds.syncToDataMart('22-140-01');
+      const record = await ds.getDataMartRecord('22-140-01');
+      expect(record).not.toBeNull();
+      expect(record!.projectCode).toBe('22-140-01');
+      expect(record!.jobNumber).toBe('22-140-01');
+      expect(record!.projectName).toBe('Caretta');
+      expect(record!.status).toBe('Construction');
+      expect(record!.sector).toBe('Commercial');
+      expect(record!.region).toBe('West Palm Beach');
+    });
+
+    it('computes financials correctly for Caretta', async () => {
+      await ds.syncToDataMart('22-140-01');
+      const record = await ds.getDataMartRecord('22-140-01');
+      expect(record!.originalContract).toBe(45000000);
+      expect(record!.changeOrders).toBe(2500000);
+      expect(record!.currentContractValue).toBe(47500000);
+      expect(record!.billingsToDate).toBe(32000000);
+    });
+
+    it('computes unbilledAmount as (OC + CO) - billings, not from financials.unbilled', async () => {
+      await ds.syncToDataMart('22-140-01');
+      const record = await ds.getDataMartRecord('22-140-01');
+      // unbilledAmount = 47500000 - 32000000 = 15500000
+      // (NOT the 4500000 from IActiveProject.financials.unbilled)
+      expect(record!.unbilledAmount).toBe(15500000);
+    });
+
+    it('computes hasUnbilledAlert:true for Caretta (32.6% >= 15%)', async () => {
+      await ds.syncToDataMart('22-140-01');
+      const record = await ds.getDataMartRecord('22-140-01');
+      // unbilledPct = 15500000 / 47500000 * 100 = 32.63%
+      expect(record!.hasUnbilledAlert).toBe(true);
+    });
+
+    it('computes hasFeeErosionAlert:false when projectedFeePct equals threshold', async () => {
+      await ds.syncToDataMart('22-140-01');
+      const record = await ds.getDataMartRecord('22-140-01');
+      // projectedFeePct = 5.0, threshold = 5.0; alert triggers only when < 5
+      expect(record!.hasFeeErosionAlert).toBe(false);
+    });
+
+    it('upserts on second sync — preserves id, updates lastSyncDate', async () => {
+      await ds.syncToDataMart('22-140-01');
+      const first = await ds.getDataMartRecord('22-140-01');
+      const firstId = first!.id;
+      const firstSync = first!.lastSyncDate;
+
+      // Small delay to ensure different timestamp
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      await ds.syncToDataMart('22-140-01');
+      const second = await ds.getDataMartRecord('22-140-01');
+      expect(second!.id).toBe(firstId);
+      expect(second!.lastSyncDate >= firstSync).toBe(true);
+
+      // Should still be only one record for this project
+      const all = await ds.getDataMartRecords();
+      const carettaRecords = all.filter(r => r.projectCode === '22-140-01');
+      expect(carettaRecords).toHaveLength(1);
+    });
+
+    it('sets meta fields: lastSyncBy and lastSyncDate', async () => {
+      await ds.syncToDataMart('22-140-01');
+      const record = await ds.getDataMartRecord('22-140-01');
+      expect(record!.lastSyncBy).toBe('MockDataService');
+      expect(new Date(record!.lastSyncDate).toISOString()).toBe(record!.lastSyncDate);
+    });
+  });
+
+  // ─── getDataMartRecords ────────────────────────────────────────────
+
+  describe('getDataMartRecords', () => {
+    it('returns empty array before any sync', async () => {
+      const records = await ds.getDataMartRecords();
+      expect(records).toEqual([]);
+    });
+
+    it('returns 14 records after triggerDataMartSync', async () => {
+      await ds.triggerDataMartSync();
+      const records = await ds.getDataMartRecords();
+      expect(records).toHaveLength(14);
+    });
+
+    it('filters by status Precon → 2 records', async () => {
+      await ds.triggerDataMartSync();
+      const records = await ds.getDataMartRecords({ status: 'Precon' });
+      expect(records).toHaveLength(2);
+      expect(records.every(r => r.status === 'Precon')).toBe(true);
+    });
+
+    it('filters by hasAlerts:true → only records with at least one alert flag', async () => {
+      await ds.triggerDataMartSync();
+      const all = await ds.getDataMartRecords();
+      const withAlerts = await ds.getDataMartRecords({ hasAlerts: true });
+      expect(withAlerts.length).toBeGreaterThan(0);
+      // Every returned record must have at least one alert flag
+      for (const r of withAlerts) {
+        expect(r.hasUnbilledAlert || r.hasScheduleAlert || r.hasFeeErosionAlert).toBe(true);
+      }
+      // Records without alerts should not be in the filtered set
+      const withoutAlerts = all.filter(
+        r => !r.hasUnbilledAlert && !r.hasScheduleAlert && !r.hasFeeErosionAlert
+      );
+      const alertCodes = new Set(withAlerts.map(r => r.projectCode));
+      for (const r of withoutAlerts) {
+        expect(alertCodes.has(r.projectCode)).toBe(false);
+      }
+    });
+  });
+
+  // ─── getDataMartRecord ─────────────────────────────────────────────
+
+  describe('getDataMartRecord', () => {
+    it('returns null for unknown projectCode before sync', async () => {
+      const record = await ds.getDataMartRecord('22-140-01');
+      expect(record).toBeNull();
+    });
+
+    it('returns correct record after syncToDataMart', async () => {
+      await ds.syncToDataMart('22-140-01');
+      const record = await ds.getDataMartRecord('22-140-01');
+      expect(record).not.toBeNull();
+      expect(record!.projectName).toBe('Caretta');
+      expect(record!.projectExecutive).toBe('Bob Cashin');
+    });
+  });
+
+  // ─── triggerDataMartSync ───────────────────────────────────────────
+
+  describe('triggerDataMartSync', () => {
+    it('returns 14 results all with success:true', async () => {
+      const results = await ds.triggerDataMartSync();
+      expect(results).toHaveLength(14);
+      expect(results.every(r => r.success)).toBe(true);
+    });
+
+    it('populates getDataMartRecords with 14 records', async () => {
+      await ds.triggerDataMartSync();
+      const records = await ds.getDataMartRecords();
+      expect(records).toHaveLength(14);
+      // Verify distinct project codes
+      const codes = new Set(records.map(r => r.projectCode));
+      expect(codes.size).toBe(14);
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Domain 3: Project Assignments
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('MockDataService — Project Assignments', () => {
+  let ds: MockDataService;
+
+  beforeEach(() => {
+    ds = new MockDataService();
+  });
+
+  // ─── getMyProjectAssignments ───────────────────────────────────────
+
+  describe('getMyProjectAssignments', () => {
+    it('returns assignments for known user email', async () => {
+      const assignments = await ds.getMyProjectAssignments('bcashin@hedrickbrothers.com');
+      expect(assignments.length).toBeGreaterThan(0);
+      expect(assignments.every(a => a.userEmail.toLowerCase() === 'bcashin@hedrickbrothers.com')).toBe(true);
+    });
+
+    it('is case-insensitive for email lookup', async () => {
+      const lower = await ds.getMyProjectAssignments('bcashin@hedrickbrothers.com');
+      const upper = await ds.getMyProjectAssignments('BCASHIN@HEDRICKBROTHERS.COM');
+      expect(lower.length).toBe(upper.length);
+      expect(lower.map(a => a.id).sort()).toEqual(upper.map(a => a.id).sort());
+    });
+
+    it('returns empty array for unknown email', async () => {
+      const assignments = await ds.getMyProjectAssignments('nobody@example.com');
+      expect(assignments).toEqual([]);
+    });
+
+    it('returns deep clone — modifying result does not affect internal state', async () => {
+      const first = await ds.getMyProjectAssignments('bcashin@hedrickbrothers.com');
+      expect(first.length).toBeGreaterThan(0);
+      first[0].assignedRole = 'MUTATED';
+
+      const second = await ds.getMyProjectAssignments('bcashin@hedrickbrothers.com');
+      expect(second[0].assignedRole).not.toBe('MUTATED');
+    });
+  });
+
+  // ─── getAccessibleProjects ─────────────────────────────────────────
+
+  describe('getAccessibleProjects', () => {
+    it('returns all lead project codes for globalAccess user (default ExecutiveLeadership)', async () => {
+      const codes = await ds.getAccessibleProjects('bcashin@hedrickbrothers.com');
+      // ExecutiveLeadership has globalAccess → returns all lead project codes
+      // Should be more than the 2 directly assigned project codes
+      expect(codes.length).toBeGreaterThan(2);
+    });
+
+    it('returns only assigned codes after setCurrentUserRole(Marketing)', async () => {
+      ds.setCurrentUserRole(RoleName.Marketing);
+      const codes = await ds.getAccessibleProjects('bcashin@hedrickbrothers.com');
+      // Marketing has no globalAccess → only project team assignments
+      const assignments = await ds.getMyProjectAssignments('bcashin@hedrickbrothers.com');
+      const assignedCodes = [...new Set(assignments.map(a => a.projectCode))];
+      expect(codes.sort()).toEqual(assignedCodes.sort());
+    });
+
+    it('returns empty for unknown user with no globalAccess', async () => {
+      ds.setCurrentUserRole(RoleName.Marketing);
+      const codes = await ds.getAccessibleProjects('nobody@example.com');
+      expect(codes).toEqual([]);
+    });
+  });
+});

--- a/packages/hbc-sp-services/src/services/__tests__/MockDataService.riskSchedule.test.ts
+++ b/packages/hbc-sp-services/src/services/__tests__/MockDataService.riskSchedule.test.ts
@@ -1,0 +1,481 @@
+import { MockDataService } from '../MockDataService';
+
+describe('MockDataService — Risk & Cost Management', () => {
+  let ds: MockDataService;
+
+  beforeEach(() => {
+    ds = new MockDataService();
+  });
+
+  // ─── getRiskCostManagement ─────────────────────────────────────────
+
+  describe('getRiskCostManagement', () => {
+    it('returns assembled record for 25-042-01 with categorized items', async () => {
+      const record = await ds.getRiskCostManagement('25-042-01');
+      expect(record).not.toBeNull();
+      expect(record!.projectCode).toBe('25-042-01');
+      expect(record!.contractType).toBe('GMP');
+      expect(record!.contractAmount).toBe(48500000);
+      expect(record!.buyoutOpportunities).toHaveLength(3);
+      expect(record!.potentialRisks).toHaveLength(4);
+      expect(record!.potentialSavings).toHaveLength(3);
+    });
+
+    it('returns null for unknown project code', async () => {
+      const record = await ds.getRiskCostManagement('BOGUS');
+      expect(record).toBeNull();
+    });
+
+    it('items have correct category assignments', async () => {
+      const record = await ds.getRiskCostManagement('25-042-01');
+      expect(record!.buyoutOpportunities.every(i => i.category === 'Buyout')).toBe(true);
+      expect(record!.potentialRisks.every(i => i.category === 'Risk')).toBe(true);
+      expect(record!.potentialSavings.every(i => i.category === 'Savings')).toBe(true);
+    });
+  });
+
+  // ─── updateRiskCostManagement ──────────────────────────────────────
+
+  describe('updateRiskCostManagement', () => {
+    it('updates fields and sets lastUpdatedAt', async () => {
+      const before = new Date().toISOString();
+      const result = await ds.updateRiskCostManagement('25-042-01', {
+        contractType: 'Lump Sum',
+      });
+      expect(result.contractType).toBe('Lump Sum');
+      expect(result.lastUpdatedAt >= before).toBe(true);
+    });
+
+    it('returns assembled record with items', async () => {
+      const result = await ds.updateRiskCostManagement('25-042-01', {});
+      expect(result.buyoutOpportunities.length).toBeGreaterThan(0);
+      expect(result.potentialRisks.length).toBeGreaterThan(0);
+      expect(result.potentialSavings.length).toBeGreaterThan(0);
+    });
+
+    it('throws for non-existent project', async () => {
+      await expect(
+        ds.updateRiskCostManagement('BOGUS', {})
+      ).rejects.toThrow();
+    });
+  });
+
+  // ─── addRiskCostItem ───────────────────────────────────────────────
+
+  describe('addRiskCostItem', () => {
+    it('creates item with auto-generated id', async () => {
+      const item = await ds.addRiskCostItem('25-042-01', {
+        category: 'Risk',
+        letter: 'E',
+        description: 'Test risk item',
+        estimatedValue: 75000,
+      });
+      expect(item.id).toBeGreaterThan(0);
+      expect(item.category).toBe('Risk');
+      expect(item.description).toBe('Test risk item');
+      expect(item.estimatedValue).toBe(75000);
+    });
+
+    it('item appears in parent record on subsequent read', async () => {
+      await ds.addRiskCostItem('25-042-01', {
+        category: 'Savings',
+        letter: 'D',
+        description: 'New savings opportunity',
+        estimatedValue: 50000,
+      });
+      const record = await ds.getRiskCostManagement('25-042-01');
+      expect(record!.potentialSavings).toHaveLength(4); // was 3
+      const found = record!.potentialSavings.find(i => i.description === 'New savings opportunity');
+      expect(found).toBeDefined();
+    });
+
+    it('sets default values for omitted fields', async () => {
+      const item = await ds.addRiskCostItem('25-042-01', {});
+      expect(item.category).toBe('Risk');
+      expect(item.letter).toBe('A');
+      expect(item.status).toBe('Open');
+      expect(item.estimatedValue).toBe(0);
+      expect(item.notes).toBe('');
+    });
+
+    it('throws for non-existent project', async () => {
+      await expect(
+        ds.addRiskCostItem('BOGUS', { description: 'test' })
+      ).rejects.toThrow();
+    });
+  });
+
+  // ─── updateRiskCostItem ────────────────────────────────────────────
+
+  describe('updateRiskCostItem', () => {
+    it('updates item fields and sets updatedDate', async () => {
+      const result = await ds.updateRiskCostItem('25-042-01', 201, {
+        status: 'Mitigated',
+        notes: 'Risk resolved via alternate approach',
+      });
+      expect(result.status).toBe('Mitigated');
+      expect(result.notes).toBe('Risk resolved via alternate approach');
+      expect(result.updatedDate).toBeDefined();
+    });
+
+    it('throws for non-existent project', async () => {
+      await expect(
+        ds.updateRiskCostItem('BOGUS', 201, { status: 'Closed' })
+      ).rejects.toThrow();
+    });
+
+    it('throws for non-existent item id', async () => {
+      await expect(
+        ds.updateRiskCostItem('25-042-01', 99999, { status: 'Closed' })
+      ).rejects.toThrow();
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Quality Concerns
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('MockDataService — Quality Concerns', () => {
+  let ds: MockDataService;
+
+  beforeEach(() => {
+    ds = new MockDataService();
+  });
+
+  describe('getQualityConcerns', () => {
+    it('returns 5 concerns for 25-042-01', async () => {
+      const concerns = await ds.getQualityConcerns('25-042-01');
+      expect(concerns).toHaveLength(5);
+      expect(concerns.every(c => c.projectCode === '25-042-01')).toBe(true);
+    });
+
+    it('returns 3 concerns for 25-115-01', async () => {
+      const concerns = await ds.getQualityConcerns('25-115-01');
+      expect(concerns).toHaveLength(3);
+    });
+
+    it('returns empty for unknown project', async () => {
+      const concerns = await ds.getQualityConcerns('BOGUS');
+      expect(concerns).toEqual([]);
+    });
+  });
+
+  describe('addQualityConcern', () => {
+    it('creates concern with auto-id and default status Open', async () => {
+      const concern = await ds.addQualityConcern('25-042-01', {
+        letter: 'F',
+        description: 'Test quality issue',
+        raisedBy: 'test@hbc.com',
+      });
+      expect(concern.id).toBeGreaterThan(0);
+      expect(concern.status).toBe('Open');
+      expect(concern.resolvedDate).toBeNull();
+      expect(concern.projectCode).toBe('25-042-01');
+    });
+
+    it('persists on subsequent read', async () => {
+      await ds.addQualityConcern('25-042-01', {
+        description: 'Persisted concern',
+      });
+      const concerns = await ds.getQualityConcerns('25-042-01');
+      expect(concerns).toHaveLength(6); // was 5
+    });
+
+    it('sets default values for all omitted fields', async () => {
+      const concern = await ds.addQualityConcern('25-042-01', {});
+      expect(concern.letter).toBe('A');
+      expect(concern.description).toBe('');
+      expect(concern.raisedBy).toBe('');
+      expect(concern.resolution).toBe('');
+      expect(concern.notes).toBe('');
+    });
+  });
+
+  describe('updateQualityConcern', () => {
+    it('updates fields and returns updated concern', async () => {
+      const result = await ds.updateQualityConcern('25-042-01', 1, {
+        status: 'Resolved',
+        resolution: 'Fixed by rework',
+        resolvedDate: '2026-02-01',
+      });
+      expect(result.status).toBe('Resolved');
+      expect(result.resolution).toBe('Fixed by rework');
+      expect(result.resolvedDate).toBe('2026-02-01');
+    });
+
+    it('throws for non-existent concern', async () => {
+      await expect(
+        ds.updateQualityConcern('25-042-01', 99999, { status: 'Closed' })
+      ).rejects.toThrow();
+    });
+
+    it('update persists on subsequent read', async () => {
+      await ds.updateQualityConcern('25-042-01', 3, { status: 'Resolved' });
+      const concerns = await ds.getQualityConcerns('25-042-01');
+      const updated = concerns.find(c => c.id === 3);
+      expect(updated!.status).toBe('Resolved');
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Safety Concerns
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('MockDataService — Safety Concerns', () => {
+  let ds: MockDataService;
+
+  beforeEach(() => {
+    ds = new MockDataService();
+  });
+
+  describe('getSafetyConcerns', () => {
+    it('returns 4 concerns for 25-042-01', async () => {
+      const concerns = await ds.getSafetyConcerns('25-042-01');
+      expect(concerns).toHaveLength(4);
+      expect(concerns.every(c => c.projectCode === '25-042-01')).toBe(true);
+    });
+
+    it('returns 3 concerns for 25-115-01', async () => {
+      const concerns = await ds.getSafetyConcerns('25-115-01');
+      expect(concerns).toHaveLength(3);
+    });
+
+    it('returns empty for unknown project', async () => {
+      const concerns = await ds.getSafetyConcerns('BOGUS');
+      expect(concerns).toEqual([]);
+    });
+  });
+
+  describe('addSafetyConcern', () => {
+    it('creates concern with default severity Medium', async () => {
+      const concern = await ds.addSafetyConcern('25-042-01', {
+        letter: 'E',
+        description: 'Test safety issue',
+        raisedBy: 'test@hbc.com',
+      });
+      expect(concern.id).toBeGreaterThan(0);
+      expect(concern.severity).toBe('Medium');
+      expect(concern.status).toBe('Open');
+      expect(concern.resolvedDate).toBeNull();
+    });
+
+    it('includes safety officer fields', async () => {
+      const concern = await ds.addSafetyConcern('25-042-01', {
+        safetyOfficerName: 'Test Officer',
+        safetyOfficerEmail: 'officer@hbc.com',
+      });
+      expect(concern.safetyOfficerName).toBe('Test Officer');
+      expect(concern.safetyOfficerEmail).toBe('officer@hbc.com');
+    });
+
+    it('persists on subsequent read', async () => {
+      await ds.addSafetyConcern('25-042-01', { description: 'New issue' });
+      const concerns = await ds.getSafetyConcerns('25-042-01');
+      expect(concerns).toHaveLength(5); // was 4
+    });
+  });
+
+  describe('updateSafetyConcern', () => {
+    it('updates fields and returns updated concern', async () => {
+      const result = await ds.updateSafetyConcern('25-042-01', 3, {
+        status: 'Resolved',
+        resolution: 'MOT plan approved and implemented',
+        resolvedDate: '2026-02-01',
+      });
+      expect(result.status).toBe('Resolved');
+      expect(result.resolution).toBe('MOT plan approved and implemented');
+    });
+
+    it('throws for non-existent concern', async () => {
+      await expect(
+        ds.updateSafetyConcern('25-042-01', 99999, { status: 'Closed' })
+      ).rejects.toThrow();
+    });
+
+    it('update persists on subsequent read', async () => {
+      await ds.updateSafetyConcern('25-115-01', 6, { status: 'Resolved' });
+      const concerns = await ds.getSafetyConcerns('25-115-01');
+      const updated = concerns.find(c => c.id === 6);
+      expect(updated!.status).toBe('Resolved');
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Project Schedule & Critical Path
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('MockDataService — Schedule & Critical Path', () => {
+  let ds: MockDataService;
+
+  beforeEach(() => {
+    ds = new MockDataService();
+  });
+
+  describe('getProjectSchedule', () => {
+    it('returns schedule for 25-042-01 with 5 critical path items', async () => {
+      const schedule = await ds.getProjectSchedule('25-042-01');
+      expect(schedule).not.toBeNull();
+      expect(schedule!.projectCode).toBe('25-042-01');
+      expect(schedule!.criticalPathConcerns).toHaveLength(5);
+      expect(schedule!.contractCalendarDays).toBe(562);
+      expect(schedule!.hasLiquidatedDamages).toBe(true);
+      expect(schedule!.liquidatedDamagesAmount).toBe(5000);
+    });
+
+    it('returns null for unknown project', async () => {
+      const schedule = await ds.getProjectSchedule('BOGUS');
+      expect(schedule).toBeNull();
+    });
+
+    it('critical path items have correct status distribution', async () => {
+      const schedule = await ds.getProjectSchedule('25-042-01');
+      const items = schedule!.criticalPathConcerns;
+      const active = items.filter(i => i.status === 'Active');
+      const monitoring = items.filter(i => i.status === 'Monitoring');
+      const resolved = items.filter(i => i.status === 'Resolved');
+      expect(active).toHaveLength(3); // 101, 102, 104
+      expect(monitoring).toHaveLength(1); // 103
+      expect(resolved).toHaveLength(1); // 105
+    });
+  });
+
+  describe('updateProjectSchedule', () => {
+    it('updates schedule fields and sets lastUpdatedAt', async () => {
+      const before = new Date().toISOString();
+      const result = await ds.updateProjectSchedule('25-042-01', {
+        teamGoalDaysAhead: 45,
+      });
+      expect(result.teamGoalDaysAhead).toBe(45);
+      expect(result.lastUpdatedAt >= before).toBe(true);
+    });
+
+    it('throws for non-existent project', async () => {
+      await expect(
+        ds.updateProjectSchedule('BOGUS', {})
+      ).rejects.toThrow();
+    });
+
+    it('returned record includes critical path items', async () => {
+      const result = await ds.updateProjectSchedule('25-042-01', {});
+      expect(result.criticalPathConcerns).toHaveLength(5);
+    });
+  });
+
+  describe('addCriticalPathItem', () => {
+    it('creates item with auto-id and defaults', async () => {
+      const item = await ds.addCriticalPathItem('25-042-01', {
+        letter: 'F',
+        description: 'New critical concern',
+        impactDescription: 'May delay Phase 3',
+      });
+      expect(item.id).toBeGreaterThan(0);
+      expect(item.status).toBe('Active');
+      expect(item.description).toBe('New critical concern');
+      expect(item.projectCode).toBe('25-042-01');
+    });
+
+    it('item appears in schedule on subsequent read', async () => {
+      await ds.addCriticalPathItem('25-042-01', {
+        description: 'Added item',
+      });
+      const schedule = await ds.getProjectSchedule('25-042-01');
+      expect(schedule!.criticalPathConcerns).toHaveLength(6); // was 5
+    });
+
+    it('throws for non-existent project', async () => {
+      await expect(
+        ds.addCriticalPathItem('BOGUS', { description: 'test' })
+      ).rejects.toThrow();
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Lessons Learned
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('MockDataService — Lessons Learned', () => {
+  let ds: MockDataService;
+
+  beforeEach(() => {
+    ds = new MockDataService();
+  });
+
+  describe('getLessonsLearned', () => {
+    it('returns 6 lessons for 25-042-01', async () => {
+      const lessons = await ds.getLessonsLearned('25-042-01');
+      expect(lessons).toHaveLength(6);
+      expect(lessons.every(l => l.projectCode === '25-042-01')).toBe(true);
+    });
+
+    it('returns 3 lessons for 25-115-01', async () => {
+      const lessons = await ds.getLessonsLearned('25-115-01');
+      expect(lessons).toHaveLength(3);
+    });
+
+    it('returns 3 lessons for 24-089-01', async () => {
+      const lessons = await ds.getLessonsLearned('24-089-01');
+      expect(lessons).toHaveLength(3);
+    });
+
+    it('returns empty for unknown project', async () => {
+      const lessons = await ds.getLessonsLearned('BOGUS');
+      expect(lessons).toEqual([]);
+    });
+  });
+
+  describe('addLessonLearned', () => {
+    it('creates lesson with auto-id and defaults', async () => {
+      const lesson = await ds.addLessonLearned('25-042-01', {
+        title: 'Test lesson',
+        description: 'A test lesson learned',
+        recommendation: 'Do this next time',
+      });
+      expect(lesson.id).toBeGreaterThan(0);
+      expect(lesson.projectCode).toBe('25-042-01');
+      expect(lesson.title).toBe('Test lesson');
+    });
+
+    it('sets default values for omitted fields', async () => {
+      const lesson = await ds.addLessonLearned('25-042-01', {});
+      expect(lesson.category).toBe('Other');
+      expect(lesson.impact).toBe('Neutral');
+      expect(lesson.phase).toBe('Construction');
+      expect(lesson.isIncludedInFinalRecord).toBe(false);
+      expect(lesson.tags).toEqual([]);
+    });
+
+    it('persists on subsequent read', async () => {
+      await ds.addLessonLearned('25-042-01', { title: 'Persisted' });
+      const lessons = await ds.getLessonsLearned('25-042-01');
+      expect(lessons).toHaveLength(7); // was 6
+      expect(lessons.find(l => l.title === 'Persisted')).toBeDefined();
+    });
+  });
+
+  describe('updateLessonLearned', () => {
+    it('updates fields and returns updated lesson', async () => {
+      const result = await ds.updateLessonLearned('25-042-01', 3, {
+        isIncludedInFinalRecord: true,
+      });
+      expect(result.isIncludedInFinalRecord).toBe(true);
+      expect(result.title).toBe('Permit re-review caused 3-week delay');
+    });
+
+    it('throws for non-existent lesson', async () => {
+      await expect(
+        ds.updateLessonLearned('25-042-01', 99999, { title: 'nope' })
+      ).rejects.toThrow();
+    });
+
+    it('update persists on subsequent read', async () => {
+      await ds.updateLessonLearned('25-042-01', 1, { category: 'Cost' });
+      const lessons = await ds.getLessonsLearned('25-042-01');
+      const updated = lessons.find(l => l.id === 1);
+      expect(updated!.category).toBe('Cost');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Provisioning Operations**: 8 new IDataService methods with real PnP.js implementations gated behind `ProvisioningRealOps` feature flag (229 total methods)
- **SharePoint Data Service**: Added caching layer, error handling, and performance instrumentation across all 229 methods; fixed 5 syntax errors where perf markers were inside type signatures
- **Test Coverage**: Added 148 new MockDataService tests across 3 suites (portfolio/buyout/riskSchedule) covering Active Projects, Data Mart, Assignments, Buyout CRUD, Commitment Workflow, Compliance, Risk/Cost, Quality, Safety, Schedule, and Lessons Learned
- **SignalR Integration**: Real-time subscriptions, broadcasts, and user presence system across hooks
- **Data Mart**: 43-column denormalized hub list with portfolio health aggregation and fire-and-forget sync
- **UI Fixes**: Resolved TS2345 build errors and lint warnings across UI pages

## Test plan
- [x] All 472 tests pass (`npx jest --ci`)
- [x] TypeScript compilation clean (`npx tsc --noEmit`)
- [x] Production build succeeds (`npm run build`)
- [ ] Manual smoke test of provisioning flow in SPFx workbench
- [ ] Verify Data Mart sync in dev tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)