### PR TITLE
feat(ops-nav): reorganize Operations sidebar navigation

### DIFF
--- a/src/webparts/hbcProjectControls/components/App.tsx
+++ b/src/webparts/hbcProjectControls/components/App.tsx
@@ -87,6 +87,7 @@ const BuyoutLogPage = lazyNamed(() => import('./pages/project/BuyoutLogPage'));
 // Inline tiny pages — kept in main bundle (no benefit from splitting)
 // ---------------------------------------------------------------------------
 import { AccessDeniedPage } from './pages/shared/AccessDeniedPage';
+import { ComingSoonPage } from './shared/ComingSoonPage';
 
 export interface IAppProps {
   dataService: IDataService;
@@ -291,6 +292,21 @@ const AppRoutes: React.FC = () => (
       } />
       <Route path="/operations/lessons-learned" element={
         <ProjectRequiredRoute><LessonsLearnedPage /></ProjectRequiredRoute>
+      } />
+      <Route path="/operations/readicheck" element={
+        <ProjectRequiredRoute><ComingSoonPage title="ReadiCheck" /></ProjectRequiredRoute>
+      } />
+      <Route path="/operations/best-practices" element={
+        <ProjectRequiredRoute><ComingSoonPage title="Best Practices" /></ProjectRequiredRoute>
+      } />
+      <Route path="/operations/constraints" element={
+        <ProjectRequiredRoute><ComingSoonPage title="Constraints" /></ProjectRequiredRoute>
+      } />
+      <Route path="/operations/permits" element={
+        <ProjectRequiredRoute><ComingSoonPage title="Permits" /></ProjectRequiredRoute>
+      } />
+      <Route path="/operations/sub-scorecard" element={
+        <ProjectRequiredRoute><ComingSoonPage title="Sub Scorecard" /></ProjectRequiredRoute>
       } />
       <Route path="/operations/gonogo" element={
         <ProjectRequiredRoute><GoNoGoScorecard /></ProjectRequiredRoute>

--- a/src/webparts/hbcProjectControls/components/layouts/NavigationSidebar.tsx
+++ b/src/webparts/hbcProjectControls/components/layouts/NavigationSidebar.tsx
@@ -141,37 +141,40 @@ const NAV_STRUCTURE: INavGroupDef[] = [
     label: 'Operations',
     groupKey: 'Operations',
     items: [
-      { label: 'Active Projects', path: '/operations', permission: PERMISSIONS.ACTIVE_PROJECTS_VIEW, hubOnly: true, featureFlag: 'ExecutiveDashboard' },
-      { label: 'Compliance Log', path: '/operations/compliance-log', permission: PERMISSIONS.COMPLIANCE_LOG_VIEW, hubOnly: true },
+      { label: 'Project Dashboard', path: '/operations/project', requiresProject: true },
     ],
     subGroups: [
       {
         label: 'Project Manual',
         items: [
-          { label: 'Project Dashboard', path: '/operations/project', requiresProject: true },
-          { label: 'Startup Checklist', path: '/operations/startup-checklist', requiresProject: true, featureFlag: 'ProjectStartup' },
           { label: 'Management Plan', path: '/operations/management-plan', requiresProject: true, featureFlag: 'ProjectManagementPlan' },
           { label: "Super's Plan", path: '/operations/superintendent-plan', requiresProject: true },
+          { label: 'Startup Checklist', path: '/operations/startup-checklist', requiresProject: true, featureFlag: 'ProjectStartup' },
+          { label: 'ReadiCheck', path: '/operations/readicheck', requiresProject: true },
+          { label: 'Best Practices', path: '/operations/best-practices', requiresProject: true },
           { label: 'Responsibility', path: '/operations/responsibility', requiresProject: true, featureFlag: 'ProjectStartup' },
-        ],
-      },
-      {
-        label: 'Commitments',
-        items: [
-          { label: 'Buyout Log', path: '/operations/buyout-log', requiresProject: true, permission: PERMISSIONS.BUYOUT_VIEW },
-          { label: 'Contract Tracking', path: '/operations/contract-tracking', requiresProject: true },
+          { label: 'Schedule', path: '/operations/schedule', requiresProject: true },
+          { label: 'Safety Concerns', path: '/operations/safety-concerns', requiresProject: true },
+          { label: 'Quality Concerns', path: '/operations/quality-concerns', requiresProject: true },
           { label: 'Closeout Checklist', path: '/operations/closeout-checklist', requiresProject: true },
         ],
       },
       {
-        label: 'Project Controls',
+        label: 'Logs & Reports',
         items: [
-          { label: 'Risk & Cost', path: '/operations/risk-cost', requiresProject: true },
-          { label: 'Schedule', path: '/operations/schedule', requiresProject: true },
-          { label: 'Quality Concerns', path: '/operations/quality-concerns', requiresProject: true },
-          { label: 'Safety Concerns', path: '/operations/safety-concerns', requiresProject: true },
+          { label: 'Buyout', path: '/operations/buyout-log', requiresProject: true, permission: PERMISSIONS.BUYOUT_VIEW },
           { label: 'Monthly Review', path: '/operations/monthly-review', requiresProject: true, featureFlag: 'MonthlyProjectReview' },
+          { label: 'Constraints', path: '/operations/constraints', requiresProject: true },
+          { label: 'Permits', path: '/operations/permits', requiresProject: true },
+          { label: 'Compliance Log', path: '/operations/compliance-log', permission: PERMISSIONS.COMPLIANCE_LOG_VIEW },
+        ],
+      },
+      {
+        label: 'Project Record',
+        items: [
           { label: 'Lessons Learned', path: '/operations/lessons-learned', requiresProject: true },
+          { label: 'Sub Scorecard', path: '/operations/sub-scorecard', requiresProject: true },
+          { label: 'Project Summary', path: '/operations/project-record', requiresProject: true },
         ],
       },
     ],

--- a/src/webparts/hbcProjectControls/components/pages/project/BuyoutLogPage.tsx
+++ b/src/webparts/hbcProjectControls/components/pages/project/BuyoutLogPage.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { HBC_COLORS, ELEVATION, RISK_INDICATOR } from '../../../theme/tokens';
 import { useAppContext } from '../../contexts/AppContext';
 import { useLeads } from '../../hooks/useLeads';
@@ -45,6 +46,7 @@ const COMMITMENT_STATUS_CONFIG: Record<CommitmentStatus, { label: string; bg: st
 // ---------------------------------------------------------------------------
 
 export const BuyoutLogPage: React.FC = () => {
+  const navigate = useNavigate();
   const { selectedProject, hasPermission, currentUser, dataService } = useAppContext();
   const { leads, fetchLeads } = useLeads();
   const {
@@ -285,6 +287,7 @@ export const BuyoutLogPage: React.FC = () => {
           <thead>
             <tr style={{ backgroundColor: HBC_COLORS.gray50, borderBottom: `2px solid ${HBC_COLORS.gray200}` }}>
               <Th>Division</Th>
+              <Th>Commitment #</Th>
               <Th>Description</Th>
               <Th align="right">Original Budget</Th>
               <Th align="right">Est. Tax</Th>
@@ -318,6 +321,16 @@ export const BuyoutLogPage: React.FC = () => {
                   onDoubleClick={() => canEdit && !isEditing && startEdit(entry)}
                 >
                   <Td>{entry.divisionCode}</Td>
+                  <Td>
+                    <span
+                      onClick={() => navigate('/operations/contract-tracking')}
+                      style={{ color: HBC_COLORS.navy, cursor: 'pointer', textDecoration: 'none', fontWeight: 500 }}
+                      onMouseEnter={e => { (e.target as HTMLElement).style.textDecoration = 'underline'; }}
+                      onMouseLeave={e => { (e.target as HTMLElement).style.textDecoration = 'none'; }}
+                    >
+                      {`CMT-${entry.divisionCode}`}
+                    </span>
+                  </Td>
                   <Td>{entry.divisionDescription}</Td>
 
                   {/* Original Budget */}

--- a/src/webparts/hbcProjectControls/components/shared/ComingSoonPage.tsx
+++ b/src/webparts/hbcProjectControls/components/shared/ComingSoonPage.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { HBC_COLORS } from '../../theme/tokens';
+import { PageHeader } from './PageHeader';
+
+interface IComingSoonPageProps {
+  title: string;
+}
+
+export const ComingSoonPage: React.FC<IComingSoonPageProps> = ({ title }) => (
+  <div>
+    <PageHeader title={title} />
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: 48, textAlign: 'center' }}>
+      <h3 style={{ margin: '0 0 8px', color: HBC_COLORS.navy, fontSize: 18 }}>Coming Soon</h3>
+      <p style={{ margin: 0, color: HBC_COLORS.gray500, fontSize: 14, maxWidth: 400 }}>
+        This module is under development and will be available in a future release.
+      </p>
+    </div>
+  </div>
+);

--- a/src/webparts/hbcProjectControls/components/shared/index.ts
+++ b/src/webparts/hbcProjectControls/components/shared/index.ts
@@ -36,3 +36,4 @@ export { ToolPermissionMatrix } from './ToolPermissionMatrix';
 export { GranularFlagEditor } from './GranularFlagEditor';
 export { PageLoader } from './PageLoader';
 export { PresenceIndicator } from './PresenceIndicator';
+export { ComingSoonPage } from './ComingSoonPage';


### PR DESCRIPTION
## Summary
- Restructured Operations nav from 2 hub items + 3 subgroups (Project Manual, Commitments, Project Controls) into 1 top-level item (Project Dashboard) + 3 new subgroups (Project Manual, Logs & Reports, Project Record)
- Added 5 Coming Soon placeholder pages: ReadiCheck, Best Practices, Constraints, Permits, Sub Scorecard
- Added Commitment # column to Buyout Log table with clickable links to Contract Tracking
- Removed Active Projects, Risk & Cost, and Contract Tracking from sidebar nav (routes preserved)

## Test plan
- [ ] Verify Operations nav shows new structure: Project Dashboard top-level, then Project Manual (10 items), Logs & Reports (5 items), Project Record (3 items)
- [ ] Verify 5 Coming Soon pages render with correct titles when navigated to
- [ ] Verify Compliance Log appears in Logs & Reports and is clickable without a project selected
- [ ] Verify Marketing group still shows its "Project Record" entry unchanged
- [ ] Verify Buyout Log table shows Commitment # column with clickable navy links navigating to Contract Tracking
- [ ] Verify removed routes (`#/operations`, `#/operations/risk-cost`, `#/operations/contract-tracking`) still load their pages directly
- [ ] TypeScript, ESLint, and Jest (488 tests) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)