### PR TITLE
feat(schedule): full P6-style schedule management module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Update this file at these specific intervals:
 
 For full historical phase logs (SP-1 through SP-7), complete 221-method table, old navigation, and detailed past pitfalls → see **CLAUDE_ARCHIVE.md**.
 
-**Last Updated:** 2026-02-17 — Schedule Module Enhanced: XER/XML parsing, 6-tab SchedulePage (+ Analysis), 8 Recharts charts, earned value metrics, advanced filters, ExportButtons, sessionStorage caching
+**Last Updated:** 2026-02-17 — Schedule Module Validation: 3 new test suites (61 tests → 550 total), parser hardening (per-row try/catch), accessibility attrs, responsive charts, ExportButtons on Analysis, loading spinner, cache invalidation
 
 **MANDATORY:** After every code change that affects the data layer, update the relevant sections before ending the session.
 
@@ -80,7 +80,7 @@ For full historical phase logs (SP-1 through SP-7), complete 221-method table, o
 
 ## §15 Current Phase Status
 
-**Phase COMPLETE**: Schedule Module (Enhanced) — 235/235 methods implemented.
+**Phase COMPLETE**: Schedule Module (Validated) — 235/235 methods implemented, 61 schedule-specific tests.
 
 Full P6-style schedule management with multi-format support:
 - **Parsing**: CSV, XER (Primavera P6), XML (MSProject + P6 PMXML) via `parseScheduleFile` dispatcher
@@ -116,7 +116,7 @@ Full P6-style schedule management with multi-format support:
 
 **Coverage**: ProvisioningService.ts 97%+ stmts/98%+ lines, projectListSchemas.ts 100%, NotificationService.ts ~65% stmts
 
-**Test Suites** (113 provisioning-related tests):
+**Test Suites** (113 provisioning-related + 61 schedule tests):
 - Service (node): ProvisioningService.test.ts (62), integration (13), MockDataService.provisioning (8), schemas (8), NotificationService.provisioning (6)
 - Component (jsdom): ProvisioningStatus.test.tsx (8), AdminPanel.provisioning.test.tsx (8)
 
@@ -125,9 +125,9 @@ Full P6-style schedule management with multi-format support:
 **Test utils**: `src/__tests__/test-utils.tsx` — `renderWithProviders` with FluentProvider + MemoryRouter + AppProvider
 
 **Run commands**:
-- `npx jest` — all 488 tests across both projects
+- `npx jest` — all 550 tests across both projects
 - `npx jest --selectProjects components` — UI tests only (16)
-- `npx jest --selectProjects sp-services` — service tests only (472)
+- `npx jest --selectProjects sp-services` — service tests only (534)
 
 ```mermaid
 graph TD
@@ -140,6 +140,9 @@ graph TD
   SP --> MOCK[MockDataService.provisioning — 8]
   SP --> SCH[projectListSchemas.test.ts — 8]
   SP --> NS[NotificationService.provisioning — 6]
+  SP --> SPAR[scheduleParser.test.ts — 33]
+  SP --> SMET[scheduleMetrics.test.ts — 15]
+  SP --> SMDS[MockDataService.schedule — 13]
 
   UI --> PSV[ProvisioningStatus.test.tsx — 8]
   UI --> AP[AdminPanel.provisioning.test.tsx — 8]
@@ -162,6 +165,8 @@ graph TD
 - `Turnover_Estimate_Overviews` is a new SP list — must be provisioned before feature goes live.
 - `Project_Data_Mart` is a new hub-site SP list (43 columns) — must be provisioned before Data Mart feature goes live.
 - Data Mart sync is fire-and-forget — never await in hooks; use `.catch(() => { /* silent */ })`.
+- XML parser tests require JSDOM's `DOMParser` (not `@xmldom/xmldom` — it lacks `querySelector`). Assign globally: `(global as unknown as Record<string, unknown>).DOMParser = new JSDOM('').window.DOMParser;`
+- Schedule metrics tests use `jest.useFakeTimers()` + `jest.setSystemTime()` for deterministic PV/SV calculations.
 - Keep `CLAUDE.md` lean — archive old content aggressively.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -15577,6 +15577,16 @@
         }
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -41480,6 +41490,7 @@
       "devDependencies": {
         "@fluentui/react-icons": "2.0.319",
         "@types/jest": "^29.5.12",
+        "@xmldom/xmldom": "^0.8.11",
         "jest": "^29.7.0",
         "jest-environment-node": "^29.7.0",
         "react": "18.2.0",

--- a/packages/hbc-sp-services/package.json
+++ b/packages/hbc-sp-services/package.json
@@ -12,18 +12,19 @@
     "test:ci": "jest --coverage --ci"
   },
   "peerDependencies": {
-    "@pnp/sp": "^4.4.1",
+    "@fluentui/react-icons": "^2.0.230",
+    "@microsoft/signalr": "^8.0.0",
     "@pnp/graph": "^4.4.1",
     "@pnp/logging": "^4.4.1",
     "@pnp/queryable": "^4.4.1",
-    "@fluentui/react-icons": "^2.0.230",
-    "@microsoft/signalr": "^8.0.0",
+    "@pnp/sp": "^4.4.1",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
   "devDependencies": {
     "@fluentui/react-icons": "2.0.319",
     "@types/jest": "^29.5.12",
+    "@xmldom/xmldom": "^0.8.11",
     "jest": "^29.7.0",
     "jest-environment-node": "^29.7.0",
     "react": "18.2.0",

--- a/packages/hbc-sp-services/src/services/__tests__/MockDataService.schedule.test.ts
+++ b/packages/hbc-sp-services/src/services/__tests__/MockDataService.schedule.test.ts
@@ -1,0 +1,225 @@
+/**
+ * MockDataService — Schedule module method tests.
+ * Validates getScheduleActivities, importScheduleActivities,
+ * updateScheduleActivity, deleteScheduleActivity, getScheduleImports, getScheduleMetrics.
+ */
+import { MockDataService } from '../MockDataService';
+import { IScheduleActivity, IScheduleImport } from '../../models/IScheduleActivity';
+
+describe('MockDataService schedule operations', () => {
+  let ds: MockDataService;
+
+  // Known project code from mock data
+  const PROJECT_CODE = 'HBC-2024-001';
+  const UNKNOWN_PROJECT = 'NONEXISTENT-999';
+
+  beforeEach(() => {
+    ds = new MockDataService();
+  });
+
+  // --- getScheduleActivities ---
+  describe('getScheduleActivities', () => {
+    it('returns activities for a known project', async () => {
+      const activities = await ds.getScheduleActivities(PROJECT_CODE);
+      expect(Array.isArray(activities)).toBe(true);
+      // Mock data should have some activities
+      expect(activities.length).toBeGreaterThanOrEqual(0);
+      if (activities.length > 0) {
+        expect(activities[0].projectCode).toBe(PROJECT_CODE);
+      }
+    });
+
+    it('returns empty array for unknown project', async () => {
+      const activities = await ds.getScheduleActivities(UNKNOWN_PROJECT);
+      expect(activities).toEqual([]);
+    });
+
+    it('returns copies (not references) of activities', async () => {
+      const a1 = await ds.getScheduleActivities(PROJECT_CODE);
+      const a2 = await ds.getScheduleActivities(PROJECT_CODE);
+      if (a1.length > 0) {
+        expect(a1[0]).not.toBe(a2[0]);
+        expect(a1[0]).toEqual(a2[0]);
+      }
+    });
+  });
+
+  // --- importScheduleActivities ---
+  describe('importScheduleActivities', () => {
+    const testActivities: IScheduleActivity[] = [
+      {
+        id: 0, projectCode: 'IMPORT-TEST', taskCode: 'IMP-001',
+        wbsCode: 'WBS.1', activityName: 'Import Test 1', activityType: 'Task Dependent',
+        status: 'Not Started', originalDuration: 10, remainingDuration: 10, actualDuration: 0,
+        baselineStartDate: null, baselineFinishDate: null,
+        plannedStartDate: '2025-06-01T00:00:00.000Z', plannedFinishDate: '2025-06-15T00:00:00.000Z',
+        actualStartDate: null, actualFinishDate: null,
+        remainingFloat: 5, freeFloat: 0, predecessors: [], successors: [],
+        successorDetails: [], resources: '', calendarName: '',
+        primaryConstraint: '', secondaryConstraint: '',
+        isCritical: false, percentComplete: 0,
+        startVarianceDays: null, finishVarianceDays: null,
+        deleteFlag: false, createdDate: '', modifiedDate: '',
+      },
+      {
+        id: 0, projectCode: 'IMPORT-TEST', taskCode: 'IMP-002',
+        wbsCode: 'WBS.1', activityName: 'Import Test 2', activityType: 'Task Dependent',
+        status: 'Completed', originalDuration: 5, remainingDuration: 0, actualDuration: 5,
+        baselineStartDate: null, baselineFinishDate: null,
+        plannedStartDate: '2025-05-01T00:00:00.000Z', plannedFinishDate: '2025-05-07T00:00:00.000Z',
+        actualStartDate: '2025-05-01T00:00:00.000Z', actualFinishDate: '2025-05-07T00:00:00.000Z',
+        remainingFloat: null, freeFloat: null, predecessors: [], successors: [],
+        successorDetails: [], resources: '', calendarName: '',
+        primaryConstraint: '', secondaryConstraint: '',
+        isCritical: false, percentComplete: 100,
+        startVarianceDays: 0, finishVarianceDays: 0,
+        deleteFlag: false, createdDate: '', modifiedDate: '',
+      },
+    ];
+
+    it('imports activities and returns them with new IDs', async () => {
+      const imported = await ds.importScheduleActivities('IMPORT-TEST', testActivities, {
+        fileName: 'test.csv',
+        format: 'P6-CSV',
+        importedBy: 'TestUser',
+        notes: 'test import',
+      });
+      expect(imported.length).toBe(2);
+      // IDs should be reassigned (not 0)
+      expect(imported[0].id).toBeGreaterThan(0);
+      expect(imported[1].id).toBeGreaterThan(imported[0].id);
+      expect(imported[0].projectCode).toBe('IMPORT-TEST');
+    });
+
+    it('replaces existing activities for the same project', async () => {
+      // First import
+      await ds.importScheduleActivities('REPLACE-TEST', testActivities, { fileName: 'first.csv' });
+      const firstResult = await ds.getScheduleActivities('REPLACE-TEST');
+      expect(firstResult.length).toBe(2);
+
+      // Second import with 1 activity
+      const singleActivity = [testActivities[0]];
+      await ds.importScheduleActivities('REPLACE-TEST', singleActivity, { fileName: 'second.csv' });
+      const secondResult = await ds.getScheduleActivities('REPLACE-TEST');
+      expect(secondResult.length).toBe(1);
+    });
+
+    it('creates an import record', async () => {
+      await ds.importScheduleActivities('IMP-RECORD-TEST', testActivities, {
+        fileName: 'record.csv',
+        format: 'P6-CSV',
+        importedBy: 'TestUser',
+        notes: 'testing',
+      });
+      const imports = await ds.getScheduleImports('IMP-RECORD-TEST');
+      expect(imports.length).toBe(1);
+      expect(imports[0].fileName).toBe('record.csv');
+      expect(imports[0].format).toBe('P6-CSV');
+      expect(imports[0].activityCount).toBe(2);
+      expect(imports[0].importedBy).toBe('TestUser');
+    });
+  });
+
+  // --- updateScheduleActivity ---
+  describe('updateScheduleActivity', () => {
+    it('updates activity fields and returns updated record', async () => {
+      // Import first to have a known activity
+      const [activity] = await ds.importScheduleActivities('UPD-TEST', [{
+        id: 0, projectCode: 'UPD-TEST', taskCode: 'UPD-001',
+        wbsCode: 'WBS.1', activityName: 'Original Name', activityType: 'Task Dependent',
+        status: 'Not Started', originalDuration: 10, remainingDuration: 10, actualDuration: 0,
+        baselineStartDate: null, baselineFinishDate: null,
+        plannedStartDate: null, plannedFinishDate: null,
+        actualStartDate: null, actualFinishDate: null,
+        remainingFloat: null, freeFloat: null, predecessors: [], successors: [],
+        successorDetails: [], resources: '', calendarName: '',
+        primaryConstraint: '', secondaryConstraint: '',
+        isCritical: false, percentComplete: 0,
+        startVarianceDays: null, finishVarianceDays: null,
+        deleteFlag: false, createdDate: '', modifiedDate: '',
+      }], { fileName: 'upd.csv' });
+
+      const updated = await ds.updateScheduleActivity('UPD-TEST', activity.id, {
+        activityName: 'Updated Name',
+        status: 'In Progress',
+        percentComplete: 50,
+      });
+
+      expect(updated.activityName).toBe('Updated Name');
+      expect(updated.status).toBe('In Progress');
+      expect(updated.percentComplete).toBe(50);
+      expect(updated.taskCode).toBe('UPD-001'); // unchanged
+    });
+
+    it('throws on missing activity', async () => {
+      await expect(
+        ds.updateScheduleActivity('NO-PROJECT', 99999, { activityName: 'Nope' })
+      ).rejects.toThrow(/not found/i);
+    });
+  });
+
+  // --- deleteScheduleActivity ---
+  describe('deleteScheduleActivity', () => {
+    it('removes the activity', async () => {
+      const [activity] = await ds.importScheduleActivities('DEL-TEST', [{
+        id: 0, projectCode: 'DEL-TEST', taskCode: 'DEL-001',
+        wbsCode: 'WBS.1', activityName: 'To Delete', activityType: 'Task Dependent',
+        status: 'Not Started', originalDuration: 10, remainingDuration: 10, actualDuration: 0,
+        baselineStartDate: null, baselineFinishDate: null,
+        plannedStartDate: null, plannedFinishDate: null,
+        actualStartDate: null, actualFinishDate: null,
+        remainingFloat: null, freeFloat: null, predecessors: [], successors: [],
+        successorDetails: [], resources: '', calendarName: '',
+        primaryConstraint: '', secondaryConstraint: '',
+        isCritical: false, percentComplete: 0,
+        startVarianceDays: null, finishVarianceDays: null,
+        deleteFlag: false, createdDate: '', modifiedDate: '',
+      }], { fileName: 'del.csv' });
+
+      await ds.deleteScheduleActivity('DEL-TEST', activity.id);
+      const remaining = await ds.getScheduleActivities('DEL-TEST');
+      expect(remaining.length).toBe(0);
+    });
+
+    it('throws on missing activity', async () => {
+      await expect(
+        ds.deleteScheduleActivity('NO-PROJECT', 99999)
+      ).rejects.toThrow(/not found/i);
+    });
+  });
+
+  // --- getScheduleImports ---
+  describe('getScheduleImports', () => {
+    it('returns imports for a project', async () => {
+      const imports = await ds.getScheduleImports(PROJECT_CODE);
+      expect(Array.isArray(imports)).toBe(true);
+    });
+
+    it('returns empty array for unknown project', async () => {
+      const imports = await ds.getScheduleImports(UNKNOWN_PROJECT);
+      expect(imports).toEqual([]);
+    });
+  });
+
+  // --- getScheduleMetrics ---
+  describe('getScheduleMetrics', () => {
+    it('returns metrics with expected shape', async () => {
+      const metrics = await ds.getScheduleMetrics(PROJECT_CODE);
+      expect(metrics).toHaveProperty('totalActivities');
+      expect(metrics).toHaveProperty('completedCount');
+      expect(metrics).toHaveProperty('inProgressCount');
+      expect(metrics).toHaveProperty('notStartedCount');
+      expect(metrics).toHaveProperty('percentComplete');
+      expect(metrics).toHaveProperty('criticalActivityCount');
+      expect(metrics).toHaveProperty('floatDistribution');
+      expect(metrics).toHaveProperty('earnedValueMetrics');
+      expect(metrics).toHaveProperty('logicMetrics');
+    });
+
+    it('returns zero-initialized metrics for unknown project', async () => {
+      const metrics = await ds.getScheduleMetrics(UNKNOWN_PROJECT);
+      expect(metrics.totalActivities).toBe(0);
+      expect(metrics.completedCount).toBe(0);
+    });
+  });
+});

--- a/packages/hbc-sp-services/src/utils/__tests__/scheduleMetrics.test.ts
+++ b/packages/hbc-sp-services/src/utils/__tests__/scheduleMetrics.test.ts
@@ -1,0 +1,293 @@
+/**
+ * scheduleMetrics — Unit tests for computeScheduleMetrics.
+ *
+ * Uses jest.useFakeTimers to freeze time for deterministic PV/SV calculations.
+ */
+import { computeScheduleMetrics } from '../scheduleMetrics';
+import { IScheduleActivity } from '../../models/IScheduleActivity';
+
+// Helper to build a minimal IScheduleActivity with sensible defaults
+function makeActivity(overrides: Partial<IScheduleActivity> = {}): IScheduleActivity {
+  return {
+    id: 1,
+    projectCode: 'TEST',
+    taskCode: 'T1',
+    wbsCode: 'WBS.1',
+    activityName: 'Test Activity',
+    activityType: 'Task Dependent',
+    status: 'Not Started',
+    originalDuration: 10,
+    remainingDuration: 10,
+    actualDuration: 0,
+    baselineStartDate: null,
+    baselineFinishDate: null,
+    plannedStartDate: null,
+    plannedFinishDate: null,
+    actualStartDate: null,
+    actualFinishDate: null,
+    remainingFloat: null,
+    freeFloat: null,
+    predecessors: [],
+    successors: [],
+    successorDetails: [],
+    resources: '',
+    calendarName: '',
+    primaryConstraint: '',
+    secondaryConstraint: '',
+    isCritical: false,
+    percentComplete: 0,
+    startVarianceDays: null,
+    finishVarianceDays: null,
+    deleteFlag: false,
+    createdDate: '2025-01-01T00:00:00.000Z',
+    modifiedDate: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('computeScheduleMetrics', () => {
+  beforeAll(() => {
+    // Freeze time to 2025-03-15 for deterministic PV calculations
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-03-15T12:00:00.000Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  // --- Empty input ---
+  it('returns zero-initialized metrics for empty array', () => {
+    const m = computeScheduleMetrics([]);
+    expect(m.totalActivities).toBe(0);
+    expect(m.completedCount).toBe(0);
+    expect(m.inProgressCount).toBe(0);
+    expect(m.notStartedCount).toBe(0);
+    expect(m.percentComplete).toBe(0);
+    expect(m.criticalActivityCount).toBe(0);
+    expect(m.negativeFloatCount).toBe(0);
+    expect(m.averageFloat).toBe(0);
+    expect(m.spiApproximation).toBe(null);
+    expect(m.negativeFloatPercent).toBe(0);
+    expect(m.earnedValueMetrics.bac).toBe(0);
+    expect(m.logicMetrics.totalRelationships).toBe(0);
+  });
+
+  // --- Status counts ---
+  it('counts statuses correctly', () => {
+    const activities = [
+      makeActivity({ id: 1, status: 'Completed', actualDuration: 10, remainingDuration: 0, percentComplete: 100 }),
+      makeActivity({ id: 2, status: 'In Progress', actualDuration: 5, remainingDuration: 5, percentComplete: 50 }),
+      makeActivity({ id: 3, status: 'Not Started', actualDuration: 0, remainingDuration: 10, percentComplete: 0 }),
+      makeActivity({ id: 4, status: 'Completed', actualDuration: 10, remainingDuration: 0, percentComplete: 100 }),
+    ];
+    const m = computeScheduleMetrics(activities);
+    expect(m.completedCount).toBe(2);
+    expect(m.inProgressCount).toBe(1);
+    expect(m.notStartedCount).toBe(1);
+    expect(m.totalActivities).toBe(4);
+  });
+
+  it('calculates percentComplete as ratio of completed to total', () => {
+    const activities = [
+      makeActivity({ id: 1, status: 'Completed', percentComplete: 100 }),
+      makeActivity({ id: 2, status: 'Completed', percentComplete: 100 }),
+      makeActivity({ id: 3, status: 'In Progress', percentComplete: 50 }),
+      makeActivity({ id: 4, status: 'Not Started', percentComplete: 0 }),
+    ];
+    const m = computeScheduleMetrics(activities);
+    // 2/4 = 50%
+    expect(m.percentComplete).toBe(50);
+  });
+
+  // --- Critical path ---
+  it('counts critical activities correctly', () => {
+    const activities = [
+      makeActivity({ id: 1, isCritical: true, remainingFloat: 0 }),
+      makeActivity({ id: 2, isCritical: true, remainingFloat: -5 }),
+      makeActivity({ id: 3, isCritical: false, remainingFloat: 10 }),
+    ];
+    const m = computeScheduleMetrics(activities);
+    expect(m.criticalActivityCount).toBe(2);
+  });
+
+  it('counts negative float activities', () => {
+    const activities = [
+      makeActivity({ id: 1, remainingFloat: -5 }),
+      makeActivity({ id: 2, remainingFloat: -1 }),
+      makeActivity({ id: 3, remainingFloat: 0 }),
+      makeActivity({ id: 4, remainingFloat: 10 }),
+      makeActivity({ id: 5, remainingFloat: null }),
+    ];
+    const m = computeScheduleMetrics(activities);
+    expect(m.negativeFloatCount).toBe(2);
+  });
+
+  // --- Float ---
+  it('calculates averageFloat excluding null values', () => {
+    const activities = [
+      makeActivity({ id: 1, remainingFloat: 10 }),
+      makeActivity({ id: 2, remainingFloat: 20 }),
+      makeActivity({ id: 3, remainingFloat: null }),
+    ];
+    const m = computeScheduleMetrics(activities);
+    // (10 + 20) / 2 = 15
+    expect(m.averageFloat).toBe(15);
+  });
+
+  it('computes float distribution buckets correctly', () => {
+    const activities = [
+      makeActivity({ id: 1, remainingFloat: -5 }),     // negative
+      makeActivity({ id: 2, remainingFloat: 0 }),       // zero
+      makeActivity({ id: 3, remainingFloat: 5 }),       // low (1-10)
+      makeActivity({ id: 4, remainingFloat: 10 }),      // low (1-10)
+      makeActivity({ id: 5, remainingFloat: 20 }),      // medium (11-30)
+      makeActivity({ id: 6, remainingFloat: 50 }),      // high (30+)
+    ];
+    const m = computeScheduleMetrics(activities);
+    expect(m.floatDistribution.negative).toBe(1);
+    expect(m.floatDistribution.zero).toBe(1);
+    expect(m.floatDistribution.low).toBe(2);
+    expect(m.floatDistribution.medium).toBe(1);
+    expect(m.floatDistribution.high).toBe(1);
+  });
+
+  it('calculates negativeFloatPercent', () => {
+    const activities = [
+      makeActivity({ id: 1, remainingFloat: -5 }),
+      makeActivity({ id: 2, remainingFloat: 10 }),
+      makeActivity({ id: 3, remainingFloat: 20 }),
+      makeActivity({ id: 4, remainingFloat: 0 }),
+    ];
+    const m = computeScheduleMetrics(activities);
+    // 1/4 = 25%
+    expect(m.negativeFloatPercent).toBe(25);
+  });
+
+  // --- Earned value ---
+  it('calculates SPI/CPI with known durations', () => {
+    const activities = [
+      makeActivity({
+        id: 1,
+        originalDuration: 20,
+        actualDuration: 20,
+        percentComplete: 100,
+        status: 'Completed',
+        baselineStartDate: '2025-01-01T00:00:00.000Z',
+        baselineFinishDate: '2025-02-01T00:00:00.000Z',
+      }),
+      makeActivity({
+        id: 2,
+        originalDuration: 20,
+        actualDuration: 10,
+        percentComplete: 50,
+        status: 'In Progress',
+        baselineStartDate: '2025-02-01T00:00:00.000Z',
+        baselineFinishDate: '2025-04-01T00:00:00.000Z',
+      }),
+    ];
+    const m = computeScheduleMetrics(activities);
+    // BAC = 40 (20 + 20)
+    expect(m.earnedValueMetrics.bac).toBe(40);
+    // EV = (100/100)*20 + (50/100)*20 = 20 + 10 = 30
+    expect(m.earnedValueMetrics.ev).toBe(30);
+    // CPI = EV / AC = 30 / 30 = 1.0
+    expect(m.earnedValueMetrics.cpi).toBe(1);
+  });
+
+  it('returns null SPI/CPI when totalDuration is 0', () => {
+    const activities = [
+      makeActivity({ id: 1, originalDuration: 0, actualDuration: 0 }),
+    ];
+    const m = computeScheduleMetrics(activities);
+    expect(m.spiApproximation).toBe(null);
+  });
+
+  it('prorates PV for activities spanning current date', () => {
+    // Freeze time is 2025-03-15
+    const activities = [
+      makeActivity({
+        id: 1,
+        originalDuration: 60,
+        actualDuration: 0,
+        percentComplete: 0,
+        baselineStartDate: '2025-02-15T00:00:00.000Z',
+        baselineFinishDate: '2025-04-15T00:00:00.000Z',
+      }),
+    ];
+    const m = computeScheduleMetrics(activities);
+    // Total span: Feb 15 to Apr 15 = 59 days
+    // Elapsed: Feb 15 to Mar 15 = 28 days
+    // PV = 60 * (28/59) ≈ 28.5 → rounded to 1 decimal
+    expect(m.earnedValueMetrics.pv).toBeGreaterThan(20);
+    expect(m.earnedValueMetrics.pv).toBeLessThan(40);
+  });
+
+  // --- Constraints ---
+  it('counts constrained activities', () => {
+    const activities = [
+      makeActivity({ id: 1, primaryConstraint: 'Must Start On' }),
+      makeActivity({ id: 2, primaryConstraint: 'Must Start On' }),
+      makeActivity({ id: 3, primaryConstraint: 'Start No Earlier Than' }),
+      makeActivity({ id: 4, primaryConstraint: '' }),
+    ];
+    const m = computeScheduleMetrics(activities);
+    expect(m.constraintAnalysis.totalConstrained).toBe(3);
+    expect(m.constraintAnalysis.byType['Must Start On']).toBe(2);
+    expect(m.constraintAnalysis.byType['Start No Earlier Than']).toBe(1);
+  });
+
+  it('handles empty constraints', () => {
+    const activities = [
+      makeActivity({ id: 1, primaryConstraint: '' }),
+      makeActivity({ id: 2, primaryConstraint: '' }),
+    ];
+    const m = computeScheduleMetrics(activities);
+    expect(m.constraintAnalysis.totalConstrained).toBe(0);
+    expect(Object.keys(m.constraintAnalysis.byType).length).toBe(0);
+  });
+
+  // --- Logic metrics ---
+  it('counts relationship types from successorDetails', () => {
+    const activities = [
+      makeActivity({
+        id: 1,
+        predecessors: [],
+        successors: ['T2', 'T3'],
+        successorDetails: [
+          { taskCode: 'T2', relationshipType: 'FS', lag: 0 },
+          { taskCode: 'T3', relationshipType: 'SS', lag: 1 },
+        ],
+      }),
+      makeActivity({
+        id: 2,
+        taskCode: 'T2',
+        predecessors: ['T1'],
+        successors: [],
+        successorDetails: [],
+      }),
+      makeActivity({
+        id: 3,
+        taskCode: 'T3',
+        predecessors: ['T1'],
+        successors: [],
+        successorDetails: [],
+      }),
+    ];
+    const m = computeScheduleMetrics(activities);
+    expect(m.logicMetrics.totalRelationships).toBe(2);
+    expect(m.logicMetrics.relationshipTypes.FS).toBe(1);
+    expect(m.logicMetrics.relationshipTypes.SS).toBe(1);
+  });
+
+  it('counts open ends (no predecessors / no successors)', () => {
+    const activities = [
+      makeActivity({ id: 1, predecessors: [], successors: ['T2'] }),           // no pred
+      makeActivity({ id: 2, taskCode: 'T2', predecessors: ['T1'], successors: [] }), // no succ
+      makeActivity({ id: 3, predecessors: ['X'], successors: ['Y'] }),         // both
+    ];
+    const m = computeScheduleMetrics(activities);
+    expect(m.logicMetrics.openEnds.noPredecessor).toBe(1);
+    expect(m.logicMetrics.openEnds.noSuccessor).toBe(1);
+  });
+});

--- a/packages/hbc-sp-services/src/utils/__tests__/scheduleParser.test.ts
+++ b/packages/hbc-sp-services/src/utils/__tests__/scheduleParser.test.ts
@@ -1,0 +1,428 @@
+/**
+ * scheduleParser — Unit tests for CSV, XER, XML parsers and the dispatcher.
+ *
+ * CSV tests use the real reference/TWNU07.csv file (1174 activities).
+ * XER/XML tests use synthetic data to avoid binary fixture files.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { JSDOM } from 'jsdom';
+import { parseScheduleCSV, parseScheduleXER, parseScheduleXML, parseScheduleFile } from '../scheduleParser';
+
+// Assign DOMParser globally for XML tests (node env has no native DOMParser).
+// JSDOM's DOMParser supports querySelector unlike @xmldom/xmldom.
+(global as unknown as Record<string, unknown>).DOMParser = new JSDOM('').window.DOMParser;
+
+const PROJECT_CODE = 'TWNU07';
+
+// Load real CSV fixture
+const csvPath = path.resolve(__dirname, '../../../../../reference/TWNU07.csv');
+const csvText = fs.readFileSync(csvPath, 'utf-8');
+
+// ---------------------------------------------------------------------------
+// parseScheduleCSV — real TWNU07 data
+// ---------------------------------------------------------------------------
+describe('parseScheduleCSV', () => {
+  const activities = parseScheduleCSV(csvText, PROJECT_CODE);
+
+  it('parses the expected number of activities (1174 data rows)', () => {
+    // 1176 lines total, 2 header rows = 1174 data rows
+    // Some rows may be filtered if missing fields, but should be very close
+    expect(activities.length).toBeGreaterThanOrEqual(1170);
+    expect(activities.length).toBeLessThanOrEqual(1175);
+  });
+
+  it('parses the first activity (SITEWORK-10) correctly', () => {
+    const first = activities[0];
+    expect(first.taskCode).toBe('SITEWORK-10');
+    expect(first.activityName).toBe('MOBILIZATION');
+    expect(first.status).toBe('Completed');
+    expect(first.wbsCode).toBe('TWNU07.8.8.2');
+    expect(first.originalDuration).toBe(2);
+    expect(first.remainingDuration).toBe(0);
+    expect(first.actualDuration).toBe(2);
+    expect(first.projectCode).toBe(PROJECT_CODE);
+  });
+
+  it('parses dates as ISO strings', () => {
+    const first = activities[0];
+    expect(first.baselineStartDate).toBe('2024-10-29T08:00:00.000Z');
+    expect(first.baselineFinishDate).toBe('2024-10-30T16:00:00.000Z');
+    expect(first.plannedStartDate).toBe('2024-10-29T08:00:00.000Z');
+    expect(first.actualStartDate).toBe('2024-10-29T08:00:00.000Z');
+  });
+
+  it('calculates percentComplete correctly for completed activities', () => {
+    const completed = activities.filter(a => a.status === 'Completed');
+    expect(completed.length).toBeGreaterThan(0);
+    completed.forEach(a => expect(a.percentComplete).toBe(100));
+  });
+
+  it('calculates variance days', () => {
+    // SITEWORK-10: same baseline and actual dates → 0 variance
+    const first = activities[0];
+    expect(first.startVarianceDays).toBe(0);
+    expect(first.finishVarianceDays).toBe(0);
+
+    // SITEWORK-50: actual finish 1/14/2025 vs baseline finish 12/13/2024 → positive variance
+    const sw50 = activities.find(a => a.taskCode === 'SITEWORK-50');
+    expect(sw50).toBeDefined();
+    expect(sw50!.finishVarianceDays).toBeGreaterThan(0);
+  });
+
+  it('parses predecessors correctly', () => {
+    const first = activities[0]; // SITEWORK-10 has predecessors: PRECON-30, SM-NTP
+    expect(first.predecessors).toEqual(['PRECON-30', 'SM-NTP']);
+  });
+
+  it('parses successors correctly', () => {
+    const first = activities[0]; // SITEWORK-10 has successors: SITEWORK-40, SITEWORK-20
+    expect(first.successors).toEqual(['SITEWORK-40', 'SITEWORK-20']);
+  });
+
+  it('parses successor details with relationship types and lag', () => {
+    // DELAY-UTLPERMIT-10 has successor: PERMIT-20: FS 1 (lag=1)
+    const delay = activities.find(a => a.taskCode === 'DELAY-UTLPERMIT-10');
+    expect(delay).toBeDefined();
+    expect(delay!.successorDetails.length).toBe(1);
+    expect(delay!.successorDetails[0]).toEqual({
+      taskCode: 'PERMIT-20',
+      relationshipType: 'FS',
+      lag: 1,
+    });
+  });
+
+  it('parses negative float', () => {
+    // DELAY-UTLPERMIT-10 has remaining float -50
+    const delay = activities.find(a => a.taskCode === 'DELAY-UTLPERMIT-10');
+    expect(delay).toBeDefined();
+    expect(delay!.remainingFloat).toBe(-50);
+    expect(delay!.isCritical).toBe(true);
+  });
+
+  it('normalizes status codes', () => {
+    const statuses = new Set(activities.map(a => a.status));
+    expect(statuses.size).toBeLessThanOrEqual(3);
+    statuses.forEach(s => expect(['Completed', 'In Progress', 'Not Started']).toContain(s));
+  });
+
+  it('assigns sequential 1-based IDs', () => {
+    expect(activities[0].id).toBe(1);
+    expect(activities[1].id).toBe(2);
+    expect(activities[activities.length - 1].id).toBe(activities.length);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(parseScheduleCSV('', PROJECT_CODE)).toEqual([]);
+  });
+
+  it('returns empty array for header-only input (fewer than 3 lines)', () => {
+    const headerOnly = 'header1,header2\ndisplay1,display2';
+    expect(parseScheduleCSV(headerOnly, PROJECT_CODE)).toEqual([]);
+  });
+
+  it('skips rows with fewer than 4 fields or empty task_code', () => {
+    const csv = 'h1,h2,h3,h4\nd1,d2,d3,d4\n,,,\nTASK-1,Not Started,WBS.1,Test Activity';
+    const result = parseScheduleCSV(csv, PROJECT_CODE);
+    expect(result.length).toBe(1);
+    expect(result[0].taskCode).toBe('TASK-1');
+  });
+
+  it('handles quoted fields with commas', () => {
+    const csv = 'h1,h2,h3,h4\nd1,d2,d3,d4\nTASK-Q,Completed,WBS.1,"Activity, with comma"';
+    const result = parseScheduleCSV(csv, PROJECT_CODE);
+    expect(result.length).toBe(1);
+    expect(result[0].activityName).toBe('Activity, with comma');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseScheduleXER — synthetic XER data
+// ---------------------------------------------------------------------------
+describe('parseScheduleXER', () => {
+  const buildXER = (tasks: string[], preds?: string[]): string => {
+    const lines = [
+      'ERMHDR\t12.0',
+      '%T\tTASK',
+      '%F\ttask_id\ttask_code\ttask_name\tstatus_code\ttarget_drtn_hr_cnt\tremain_drtn_hr_cnt\ttarget_start_date\ttarget_end_date\tearly_start_date\tearly_end_date\tact_start_date\tact_end_date\ttotal_float_hr_cnt\tfree_float_hr_cnt\ttask_type\twbs_id\trsrc_name\tclndr_name\tcstr_type\tdelete_flag',
+      ...tasks.map(t => `%R\t${t}`),
+    ];
+    if (preds && preds.length > 0) {
+      lines.push(
+        '%T\tTASKPRED',
+        '%F\ttask_id\tpred_task_id\tpred_type\tlag_hr_cnt',
+        ...preds.map(p => `%R\t${p}`),
+      );
+    }
+    return lines.join('\n');
+  };
+
+  it('parses basic task data from TASK table', () => {
+    const xer = buildXER([
+      '100\tA1010\tMobilization\tTK_Complete\t80\t0\t2025-01-02 08:00\t2025-01-15 16:00\t2025-01-02 08:00\t2025-01-15 16:00\t2025-01-02 08:00\t2025-01-15 16:00\t0\t0\tTT_Task\tWBS.1\tJohn\tStandard\t\t',
+    ]);
+    const result = parseScheduleXER(xer, 'TEST');
+    expect(result.length).toBe(1);
+    expect(result[0].taskCode).toBe('A1010');
+    expect(result[0].activityName).toBe('Mobilization');
+    expect(result[0].status).toBe('Completed');
+    expect(result[0].projectCode).toBe('TEST');
+  });
+
+  it('maps XER status codes correctly', () => {
+    const xer = buildXER([
+      '100\tT1\tTask 1\tTK_Complete\t80\t0\t\t\t\t\t\t\t\t\t\t\t\t\t\t',
+      '200\tT2\tTask 2\tTK_Active\t80\t40\t\t\t\t\t\t\t\t\t\t\t\t\t\t',
+      '300\tT3\tTask 3\tTK_NotStart\t80\t80\t\t\t\t\t\t\t\t\t\t\t\t\t\t',
+    ]);
+    const result = parseScheduleXER(xer, 'TEST');
+    expect(result[0].status).toBe('Completed');
+    expect(result[1].status).toBe('In Progress');
+    expect(result[2].status).toBe('Not Started');
+  });
+
+  it('converts hours to days for duration', () => {
+    const xer = buildXER([
+      '100\tT1\tTask\tTK_NotStart\t80\t80\t\t\t\t\t\t\t\t\t\t\t\t\t\t',
+    ]);
+    const result = parseScheduleXER(xer, 'TEST');
+    // 80 hours / 8 = 10 days
+    expect(result[0].originalDuration).toBe(10);
+    expect(result[0].remainingDuration).toBe(10);
+  });
+
+  it('builds predecessor/successor relationships from TASKPRED table', () => {
+    const xer = buildXER(
+      [
+        '100\tA1010\tFirst Task\tTK_Complete\t80\t0\t\t\t\t\t\t\t\t\t\t\t\t\t\t',
+        '200\tA1020\tSecond Task\tTK_Active\t80\t40\t\t\t\t\t\t\t\t\t\t\t\t\t\t',
+      ],
+      ['200\t100\tPR_FS\t0'], // Task 200 has predecessor 100
+    );
+    const result = parseScheduleXER(xer, 'TEST');
+    // Task 200 (A1020) should have A1010 as predecessor
+    const second = result.find(a => a.taskCode === 'A1020');
+    expect(second!.predecessors).toEqual(['A1010']);
+
+    // Task 100 (A1010) should have A1020 as successor
+    const first = result.find(a => a.taskCode === 'A1010');
+    expect(first!.successors).toEqual(['A1020']);
+  });
+
+  it('maps relationship types from XER format', () => {
+    const xer = buildXER(
+      [
+        '100\tT1\tTask 1\tTK_NotStart\t80\t80\t\t\t\t\t\t\t\t\t\t\t\t\t\t',
+        '200\tT2\tTask 2\tTK_NotStart\t80\t80\t\t\t\t\t\t\t\t\t\t\t\t\t\t',
+      ],
+      ['200\t100\tPR_SS\t16'], // SS with 16hr lag
+    );
+    const result = parseScheduleXER(xer, 'TEST');
+    const first = result.find(a => a.taskCode === 'T1');
+    expect(first!.successorDetails[0].relationshipType).toBe('SS');
+    expect(first!.successorDetails[0].lag).toBe(2); // 16 hours / 8 = 2 days
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(parseScheduleXER('', 'TEST')).toEqual([]);
+  });
+
+  it('returns empty array when no TASK table exists', () => {
+    const xer = '%T\tCALENDAR\n%F\tclndr_id\tclndr_name\n%R\t1\tStandard';
+    expect(parseScheduleXER(xer, 'TEST')).toEqual([]);
+  });
+
+  it('handles float values', () => {
+    const xer = buildXER([
+      '100\tT1\tTask\tTK_Active\t80\t40\t\t\t\t\t\t\t-40\t0\t\t\t\t\t\t',
+    ]);
+    const result = parseScheduleXER(xer, 'TEST');
+    expect(result[0].remainingFloat).toBe(-5); // -40 hours / 8 = -5 days
+    expect(result[0].isCritical).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseScheduleXML — synthetic XML data
+// ---------------------------------------------------------------------------
+describe('parseScheduleXML', () => {
+  it('parses MSProject XML format', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Project>
+  <Tasks>
+    <Task>
+      <UID>0</UID>
+      <Name>Project Root</Name>
+    </Task>
+    <Task>
+      <UID>1</UID>
+      <Name>Mobilization</Name>
+      <Duration>PT80H0M0S</Duration>
+      <Start>2025-01-02T08:00:00</Start>
+      <Finish>2025-01-15T16:00:00</Finish>
+      <PercentComplete>100</PercentComplete>
+      <WBS>1.1</WBS>
+      <Critical>1</Critical>
+      <TotalSlack>PT0H0M0S</TotalSlack>
+      <PredecessorLink>
+        <PredecessorUID>0</PredecessorUID>
+        <Type>1</Type>
+      </PredecessorLink>
+    </Task>
+    <Task>
+      <UID>2</UID>
+      <Name>Excavation</Name>
+      <Duration>PT160H0M0S</Duration>
+      <Start>2025-01-16T08:00:00</Start>
+      <Finish>2025-02-05T16:00:00</Finish>
+      <PercentComplete>50</PercentComplete>
+      <WBS>1.2</WBS>
+    </Task>
+  </Tasks>
+</Project>`;
+    const result = parseScheduleXML(xml, 'TEST');
+    // UID 0 is skipped (root task)
+    expect(result.length).toBe(2);
+    expect(result[0].taskCode).toBe('MSP-1');
+    expect(result[0].activityName).toBe('Mobilization');
+    expect(result[0].status).toBe('Completed');
+    expect(result[0].percentComplete).toBe(100);
+    expect(result[0].isCritical).toBe(true);
+    // Duration: 80H / 8 = 10 days
+    expect(result[0].originalDuration).toBe(10);
+  });
+
+  it('auto-detects P6 PMXML format by root element', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<APIBusinessObjects>
+  <Project>
+    <Activity>
+      <Id>A1010</Id>
+      <Name>Mobilization</Name>
+      <Status>Completed</Status>
+      <PlannedDuration>10</PlannedDuration>
+      <ActualDuration>10</ActualDuration>
+      <RemainingDuration>0</RemainingDuration>
+      <PlannedStartDate>2025-01-02T08:00:00</PlannedStartDate>
+      <PlannedFinishDate>2025-01-15T16:00:00</PlannedFinishDate>
+    </Activity>
+  </Project>
+</APIBusinessObjects>`;
+    const result = parseScheduleXML(xml, 'TEST');
+    expect(result.length).toBe(1);
+    expect(result[0].taskCode).toBe('A1010');
+    expect(result[0].status).toBe('Completed');
+    expect(result[0].originalDuration).toBe(10);
+  });
+
+  it('returns empty array for XML with parsererror', () => {
+    const badXml = '<Project><Task><UID>1</UID><Name>Test</Task>'; // unclosed tag
+    const result = parseScheduleXML(badXml, 'TEST');
+    // xmldom may or may not produce parsererror for this; but it shouldn't crash
+    // Just verify it doesn't throw
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it('parses MSProject duration format PT480H0M0S correctly', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Project>
+  <Tasks>
+    <Task>
+      <UID>1</UID>
+      <Name>Long Task</Name>
+      <Duration>PT480H0M0S</Duration>
+      <PercentComplete>0</PercentComplete>
+    </Task>
+  </Tasks>
+</Project>`;
+    const result = parseScheduleXML(xml, 'TEST');
+    expect(result.length).toBe(1);
+    // 480 hours / 8 = 60 days
+    expect(result[0].originalDuration).toBe(60);
+    expect(result[0].status).toBe('Not Started');
+  });
+
+  it('maps PercentComplete to status', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Project>
+  <Tasks>
+    <Task>
+      <UID>1</UID><Name>Done</Name><Duration>PT8H0M0S</Duration><PercentComplete>100</PercentComplete>
+    </Task>
+    <Task>
+      <UID>2</UID><Name>Half</Name><Duration>PT16H0M0S</Duration><PercentComplete>50</PercentComplete>
+    </Task>
+    <Task>
+      <UID>3</UID><Name>New</Name><Duration>PT24H0M0S</Duration><PercentComplete>0</PercentComplete>
+    </Task>
+  </Tasks>
+</Project>`;
+    const result = parseScheduleXML(xml, 'TEST');
+    expect(result[0].status).toBe('Completed');
+    expect(result[1].status).toBe('In Progress');
+    expect(result[2].status).toBe('Not Started');
+  });
+
+  it('parses PredecessorLink with type and lag', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Project>
+  <Tasks>
+    <Task>
+      <UID>1</UID><Name>First</Name><Duration>PT8H0M0S</Duration><PercentComplete>0</PercentComplete>
+    </Task>
+    <Task>
+      <UID>2</UID><Name>Second</Name><Duration>PT8H0M0S</Duration><PercentComplete>0</PercentComplete>
+      <PredecessorLink>
+        <PredecessorUID>1</PredecessorUID>
+        <Type>1</Type>
+        <LinkLag>9600</LinkLag>
+      </PredecessorLink>
+    </Task>
+  </Tasks>
+</Project>`;
+    const result = parseScheduleXML(xml, 'TEST');
+    const second = result.find(a => a.taskCode === 'MSP-2');
+    expect(second).toBeDefined();
+    expect(second!.predecessors.length).toBe(1);
+    // Type 1 = FS
+    expect(second!.successorDetails[0].relationshipType).toBe('FS');
+    // LinkLag 9600 in tenths of minutes → 9600 / 4800 = 2 days
+    expect(second!.successorDetails[0].lag).toBe(2);
+  });
+
+  it('returns empty array for empty XML', () => {
+    const xml = '<?xml version="1.0" encoding="UTF-8"?><Project></Project>';
+    const result = parseScheduleXML(xml, 'TEST');
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseScheduleFile — dispatcher
+// ---------------------------------------------------------------------------
+describe('parseScheduleFile', () => {
+  it('routes P6-CSV to CSV parser', () => {
+    const csv = 'h1,h2,h3,h4\nd1,d2,d3,d4\nTASK-1,Not Started,WBS.1,Test';
+    const result = parseScheduleFile(csv, 'P6-CSV', 'TEST');
+    expect(result.length).toBe(1);
+    expect(result[0].taskCode).toBe('TASK-1');
+  });
+
+  it('routes P6-XER to XER parser', () => {
+    const xer = [
+      '%T\tTASK',
+      '%F\ttask_id\ttask_code\ttask_name\tstatus_code\ttarget_drtn_hr_cnt\tremain_drtn_hr_cnt',
+      '%R\t100\tX1\tXER Task\tTK_NotStart\t80\t80',
+    ].join('\n');
+    const result = parseScheduleFile(xer, 'P6-XER', 'TEST');
+    expect(result.length).toBe(1);
+    expect(result[0].taskCode).toBe('X1');
+  });
+
+  it('routes MSProject-XML to XML parser', () => {
+    const xml = `<?xml version="1.0"?><Project><Tasks><Task><UID>1</UID><Name>XML Task</Name><Duration>PT8H0M0S</Duration><PercentComplete>0</PercentComplete></Task></Tasks></Project>`;
+    const result = parseScheduleFile(xml, 'MSProject-XML', 'TEST');
+    expect(result.length).toBe(1);
+    expect(result[0].taskCode).toBe('MSP-1');
+  });
+});

--- a/src/webparts/hbcProjectControls/components/hooks/useScheduleActivities.ts
+++ b/src/webparts/hbcProjectControls/components/hooks/useScheduleActivities.ts
@@ -142,7 +142,11 @@ export function useScheduleActivities() {
     setError(null);
     try {
       const updated = await dataService.updateScheduleActivity(projectCode, activityId, data);
-      setActivities(prev => prev.map(a => a.id === activityId ? updated : a));
+      setActivities(prev => {
+        const newList = prev.map(a => a.id === activityId ? updated : a);
+        writeActivityCache(projectCode, newList);
+        return newList;
+      });
       broadcastScheduleChange(activityId, 'updated', 'Activity updated');
       dataService.syncToDataMart(projectCode).catch(() => { /* silent */ });
       return updated;
@@ -159,7 +163,11 @@ export function useScheduleActivities() {
     setError(null);
     try {
       await dataService.deleteScheduleActivity(projectCode, activityId);
-      setActivities(prev => prev.filter(a => a.id !== activityId));
+      setActivities(prev => {
+        const newList = prev.filter(a => a.id !== activityId);
+        writeActivityCache(projectCode, newList);
+        return newList;
+      });
       broadcastScheduleChange(activityId, 'deleted', 'Activity deleted');
       dataService.syncToDataMart(projectCode).catch(() => { /* silent */ });
     } catch (err) {

--- a/src/webparts/hbcProjectControls/components/pages/project/ScheduleAnalysisTab.tsx
+++ b/src/webparts/hbcProjectControls/components/pages/project/ScheduleAnalysisTab.tsx
@@ -8,10 +8,12 @@ import {
 } from 'recharts';
 import { IScheduleActivity, IScheduleMetrics } from '@hbc/sp-services';
 import { HBC_COLORS, ELEVATION } from '../../../theme/tokens';
+import { ExportButtons } from '../../shared/ExportButtons';
 
 interface IScheduleAnalysisTabProps {
   activities: IScheduleActivity[];
   metrics: IScheduleMetrics;
+  projectCode: string;
 }
 
 const CHART_COLORS = [HBC_COLORS.navy, HBC_COLORS.orange, HBC_COLORS.info, HBC_COLORS.success, HBC_COLORS.warning, HBC_COLORS.error];
@@ -23,7 +25,7 @@ const FLOAT_COLORS: Record<string, string> = {
   high: HBC_COLORS.success,
 };
 
-export const ScheduleAnalysisTab: React.FC<IScheduleAnalysisTabProps> = ({ activities, metrics }) => {
+export const ScheduleAnalysisTab: React.FC<IScheduleAnalysisTabProps> = ({ activities, metrics, projectCode }) => {
   if (activities.length === 0) {
     return (
       <div style={{ padding: 48, textAlign: 'center', color: HBC_COLORS.gray400 }}>
@@ -33,7 +35,15 @@ export const ScheduleAnalysisTab: React.FC<IScheduleAnalysisTabProps> = ({ activ
   }
 
   return (
-    <div id="schedule-analysis-charts" style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 16 }}>
+    <>
+    <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 12 }}>
+      <ExportButtons
+        pdfElementId="schedule-analysis-charts"
+        filename={`schedule-analysis-${projectCode}`}
+        title="Schedule Analysis"
+      />
+    </div>
+    <div id="schedule-analysis-charts" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(440px, 1fr))', gap: 16 }}>
       <VarianceChart activities={activities} />
       <FloatDistributionChart metrics={metrics} />
       <SensitivityChart activities={activities} />
@@ -43,6 +53,7 @@ export const ScheduleAnalysisTab: React.FC<IScheduleAnalysisTabProps> = ({ activ
       <StatusBreakdownChart metrics={metrics} />
       <EarnedValueChart metrics={metrics} />
     </div>
+    </>
   );
 };
 
@@ -346,7 +357,7 @@ const EarnedValueChart: React.FC<{ metrics: IScheduleMetrics }> = ({ metrics }) 
 // ---------------------------------------------------------------------------
 
 const ChartCard: React.FC<{ title: string; subtitle?: string; children: React.ReactNode }> = ({ title, subtitle, children }) => (
-  <div style={cardStyle}>
+  <div style={cardStyle} role="img" aria-label={`${title}${subtitle ? `: ${subtitle}` : ''}`}>
     <div style={{ fontSize: 14, fontWeight: 600, color: HBC_COLORS.navy, marginBottom: 2 }}>{title}</div>
     {subtitle && <div style={{ fontSize: 11, color: HBC_COLORS.gray400, marginBottom: 12 }}>{subtitle}</div>}
     {children}

--- a/src/webparts/hbcProjectControls/components/pages/project/SchedulePage.tsx
+++ b/src/webparts/hbcProjectControls/components/pages/project/SchedulePage.tsx
@@ -209,17 +209,19 @@ export const SchedulePage: React.FC = () => {
         subtitle={projectCode}
         breadcrumb={<Breadcrumb items={breadcrumbs} />}
         actions={canImport ? (
-          <button onClick={() => setShowImport(true)} style={btnPrimary}>Import Schedule</button>
+          <button onClick={() => setShowImport(true)} style={btnPrimary} aria-label="Import schedule file">Import Schedule</button>
         ) : undefined}
       />
 
       {/* Tab Bar */}
-      <div style={{ display: 'flex', gap: 0, borderBottom: `2px solid ${HBC_COLORS.gray200}`, marginBottom: 24 }}>
+      <div role="tablist" aria-label="Schedule management tabs" style={{ display: 'flex', gap: 0, borderBottom: `2px solid ${HBC_COLORS.gray200}`, marginBottom: 24 }}>
         {TABS.map(tab => {
           if (tab === 'import' && !canImport) return null;
           return (
             <button
               key={tab}
+              role="tab"
+              aria-selected={activeTab === tab}
               onClick={() => setTab(tab)}
               style={{
                 padding: '10px 20px',
@@ -287,7 +289,7 @@ export const SchedulePage: React.FC = () => {
       )}
 
       {activeTab === 'analysis' && (
-        <ScheduleAnalysisTab activities={activities} metrics={metrics} />
+        <ScheduleAnalysisTab activities={activities} metrics={metrics} projectCode={projectCode} />
       )}
 
       {activeTab === 'import' && canImport && (
@@ -445,19 +447,20 @@ const ActivitiesTab: React.FC<IActivitiesTabProps> = ({
         value={search}
         onChange={e => onSearchChange(e.target.value)}
         style={{ ...inputStyle, flex: 1 }}
+        aria-label="Search schedule activities"
       />
-      <select value={statusFilter} onChange={e => onStatusFilterChange(e.target.value)} style={{ ...inputStyle, width: 150 }}>
+      <select value={statusFilter} onChange={e => onStatusFilterChange(e.target.value)} style={{ ...inputStyle, width: 150 }} aria-label="Filter by status">
         <option value="all">All Statuses</option>
         {STATUS_OPTIONS.map(s => <option key={s} value={s}>{s}</option>)}
       </select>
       {wbsPrefixes.length > 0 && (
-        <select value={wbsFilter} onChange={e => onWbsFilterChange(e.target.value)} style={{ ...inputStyle, width: 150 }}>
+        <select value={wbsFilter} onChange={e => onWbsFilterChange(e.target.value)} style={{ ...inputStyle, width: 150 }} aria-label="Filter by WBS">
           <option value="all">All WBS</option>
           {wbsPrefixes.map(w => <option key={w} value={w}>{w}</option>)}
         </select>
       )}
       {activityTypes.length > 1 && (
-        <select value={actTypeFilter} onChange={e => onActTypeFilterChange(e.target.value)} style={{ ...inputStyle, width: 160 }}>
+        <select value={actTypeFilter} onChange={e => onActTypeFilterChange(e.target.value)} style={{ ...inputStyle, width: 160 }} aria-label="Filter by activity type">
           <option value="all">All Types</option>
           {activityTypes.map(t => <option key={t} value={t}>{t}</option>)}
         </select>
@@ -471,14 +474,14 @@ const ActivitiesTab: React.FC<IActivitiesTabProps> = ({
     {/* Filters — Row 2: Date range + Float range */}
     <div style={{ display: 'flex', gap: 12, marginBottom: 16, alignItems: 'center' }}>
       <label style={{ fontSize: 12, color: HBC_COLORS.gray500, whiteSpace: 'nowrap' }}>Start from:</label>
-      <input type="date" value={dateStart} onChange={e => onDateStartChange(e.target.value)} style={{ ...inputStyle, width: 140 }} />
+      <input type="date" value={dateStart} onChange={e => onDateStartChange(e.target.value)} style={{ ...inputStyle, width: 140 }} aria-label="Filter date range start" />
       <label style={{ fontSize: 12, color: HBC_COLORS.gray500, whiteSpace: 'nowrap' }}>to:</label>
-      <input type="date" value={dateEnd} onChange={e => onDateEndChange(e.target.value)} style={{ ...inputStyle, width: 140 }} />
+      <input type="date" value={dateEnd} onChange={e => onDateEndChange(e.target.value)} style={{ ...inputStyle, width: 140 }} aria-label="Filter date range end" />
       <div style={{ width: 1, height: 20, backgroundColor: HBC_COLORS.gray200 }} />
       <label style={{ fontSize: 12, color: HBC_COLORS.gray500, whiteSpace: 'nowrap' }}>Float:</label>
-      <input type="number" placeholder="Min" value={floatMin} onChange={e => onFloatMinChange(e.target.value)} style={{ ...inputStyle, width: 70 }} />
+      <input type="number" placeholder="Min" value={floatMin} onChange={e => onFloatMinChange(e.target.value)} style={{ ...inputStyle, width: 70 }} aria-label="Minimum float filter" />
       <span style={{ fontSize: 12, color: HBC_COLORS.gray500 }}>-</span>
-      <input type="number" placeholder="Max" value={floatMax} onChange={e => onFloatMaxChange(e.target.value)} style={{ ...inputStyle, width: 70 }} />
+      <input type="number" placeholder="Max" value={floatMax} onChange={e => onFloatMaxChange(e.target.value)} style={{ ...inputStyle, width: 70 }} aria-label="Maximum float filter" />
       <div style={{ flex: 1 }} />
       <ExportButtons
         pdfElementId="schedule-activities-table"
@@ -805,14 +808,20 @@ const Th: React.FC<{ children: React.ReactNode; align?: string }> = ({ children,
   </th>
 );
 
-const ThSort: React.FC<{ children: React.ReactNode; field: SortField; current: SortField; dir: SortDir; onSort: (f: SortField) => void }> = ({ children, field, current, dir, onSort }) => (
-  <th
-    onClick={() => onSort(field)}
-    style={{ padding: '10px 8px', textAlign: 'left', fontWeight: 600, fontSize: 11, color: HBC_COLORS.gray600, textTransform: 'uppercase', letterSpacing: '0.3px', whiteSpace: 'nowrap', cursor: 'pointer', userSelect: 'none' }}
-  >
-    {children} {current === field ? (dir === 'asc' ? '\u25B2' : '\u25BC') : ''}
-  </th>
-);
+const ThSort: React.FC<{ children: React.ReactNode; field: SortField; current: SortField; dir: SortDir; onSort: (f: SortField) => void }> = ({ children, field, current, dir, onSort }) => {
+  const ariaSort = current === field ? (dir === 'asc' ? 'ascending' : 'descending') : 'none';
+  return (
+    <th
+      onClick={() => onSort(field)}
+      onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSort(field); } }}
+      tabIndex={0}
+      aria-sort={ariaSort as 'ascending' | 'descending' | 'none'}
+      style={{ padding: '10px 8px', textAlign: 'left', fontWeight: 600, fontSize: 11, color: HBC_COLORS.gray600, textTransform: 'uppercase', letterSpacing: '0.3px', whiteSpace: 'nowrap', cursor: 'pointer', userSelect: 'none' }}
+    >
+      {children} {current === field ? (dir === 'asc' ? '\u25B2' : '\u25BC') : ''}
+    </th>
+  );
+};
 
 const Td: React.FC<{ children: React.ReactNode; align?: string; bold?: boolean }> = ({ children, align, bold }) => (
   <td style={{ padding: '8px 8px', textAlign: (align as 'left') || 'left', fontWeight: bold ? 600 : 400, whiteSpace: 'nowrap', verticalAlign: 'middle' }}>


### PR DESCRIPTION
## Summary
- **Full P6-style schedule management** with 6 tabs (Overview, Activities, Gantt, Critical Path, Analysis, Import) and 6 new IDataService methods
- **Multi-format parsing**: CSV (P6), XER (Primavera P6), XML (MSProject + P6 PMXML) via `parseScheduleFile` dispatcher
- **Analysis tab**: 8 Recharts chart sections (variance scatter, float distribution, near-critical bar, schedule health radar, logic metrics pie, constraint analysis, status donut, earned value combo)
- **Enhanced metrics**: `computeScheduleMetrics()` with earned value (BAC/EV/PV/SV/SPI/CPI), constraint analysis, logic metrics, float distribution
- **61 schedule-specific tests**: scheduleParser (33), scheduleMetrics (15), MockDataService.schedule (13)
- **Parser hardening**: per-row try/catch in CSV/XER/XML parsers for resilience against malformed data
- **Accessibility**: ARIA attributes on dialog, tabs, sortable headers (keyboard support), filters, chart cards
- **UX polish**: responsive chart grid, ExportButtons on Analysis tab, loading spinner during file parsing, sessionStorage caching with 5-min TTL and mutation-aware invalidation
- **Also includes**: subcontract approval workflow, startup/closeout checklist unification, contract tracking panel, project settings page, buyout log enhancements

## Test plan
- [x] `npx tsc -p tsconfig.json` in package dir — 0 errors
- [x] `npx tsc --noEmit` at root — 0 errors
- [x] `npm run lint` — 0 errors (1 pre-existing warning)
- [x] `npx jest` — 550 tests pass across 22 suites
- [ ] Manual: Import TWNU07.csv via Import tab, verify parse preview and activities table
- [ ] Manual: Verify Analysis tab charts render on narrow viewport (single column)
- [ ] Manual: Verify tab keyboard navigation and screen reader announces aria-labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)