### PR TITLE
Standalone Graph RBAC context detection docs and E2E hardening

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,9 @@
 - [ ] Ran `npx tsc --noEmit` — no type errors
 - [ ] Ran `npm run lint` — no errors
 - [ ] Ran `npm run test:a11y` — zero WCAG 2.2 AA violations
+- [ ] Ran standalone RBAC verification (`npm run test --workspace=packages/hbc-sp-services -- StandaloneRbacResolver`)
+- [ ] Ran standalone E2E verification (`npm run test:e2e -- playwright/mode-switch.spec.ts playwright/offline-mode.spec.ts playwright/standalone-auth.spec.ts`)
+- [ ] Updated `/docs/standalone-mode.md` for any standalone auth/RBAC behavior change
 - [ ] Verified in Storybook — Accessibility panel shows 0 violations for affected stories
 - [ ] If new components added: included a Storybook story that passes axe scan
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ For full historical phase logs (SP-1 through SP-7), complete 221-method table, o
 - **After completing a data service chunk**, run `/review-chunk` to scan real stub counts and generate CLAUDE.md updates.
 - **Available commands**: `/verify-changes` (quick), `/verify-full-build` (full), `/status` (overview), `/permissions` (allowlist), `/sp-progress` (stub scan), `/review-chunk` (post-chunk).
 - `npm run verify:standalone` → Standalone validation guard (env + browser-node-core + Vite production build)
+- `npm run test --workspace=packages/hbc-sp-services -- StandaloneRbacResolver` → Standalone Graph-RBAC resolver safety checks
+- `npm run test:e2e -- playwright/mode-switch.spec.ts playwright/offline-mode.spec.ts playwright/standalone-auth.spec.ts` → Standalone shell/mode/offline E2E smoke
 - `npm run storybook` → Storybook dev server at http://localhost:6006
 - `npm run build-storybook` → Static build to storybook-static/
 - `npm run test:e2e` → Playwright E2E (starts dev server automatically)
@@ -263,6 +265,9 @@ graph TD
 - **ECharts**: NEVER import `* as echarts from 'echarts'` (disables tree-shaking). Use `echarts/core` + `echarts.use([...])`.
 - **SPFx/browser runtime**: Never import Node core modules (`crypto`, `fs`, `path`, etc.) in `src/` or `packages/hbc-sp-services/src/` service code. Use browser APIs (e.g., `globalThis.crypto.subtle`) to avoid webpack ship-bundle failures.
 - **Standalone env gate**: `VITE_DATA_SERVICE_MODE` must be `mock|standalone`; when `standalone`, require valid `VITE_AAD_CLIENT_ID`, `VITE_AAD_TENANT_ID`, and HTTPS `VITE_SP_HUB_URL` (`npm run validate:standalone-env`).
+- **Standalone context detection**: `createStandaloneRuntimeContext()` resolves live site URL from SharePoint, then `detectSiteContext()` determines hub/project context. `VITE_SP_SITE_URL` is optional override only.
+- **Standalone cross-tenant guard**: standalone runtime blocks if detected site origin differs from configured hub origin (prevents accidental cross-tenant queries).
+- **Standalone Graph RBAC fallback**: Graph `/me/transitiveMemberOf` failures must fail-soft to email-based role matching from `App_Roles.UserOrGroup`; never hard-fail app init solely due to missing `Group.Read.All` consent.
 - **SWA deploy safety**: Keep `public/staticwebapp.config.json` with SPA fallback exclusions for `/sw.js`, `/manifest.json`, `/offline.html`, `/icons/*`, `/assets/*` to preserve PWA behavior.
 - **ECharts**: NEVER build `EChartsOption` inline in JSX — always `useMemo`. Radar `indicator` array ≠ Recharts data array shape.
 - **ECharts Jest**: `echarts-for-react` + `echarts/*` mocked in `src/__mocks__/`. Assert on `data-chart-type` attr. `ResizeObserver` stubbed on `window` in `src/__tests__/setup.ts`.

--- a/dev/auth/createStandaloneSpfi.ts
+++ b/dev/auth/createStandaloneSpfi.ts
@@ -1,20 +1,152 @@
 /**
- * Creates a PnP SPFI instance authenticated via MSAL for standalone dev mode.
- * Mirrors the SPFx WebPart pattern: spfi().using(SPFx(context)) → spfi().using(DefaultHeaders(), DefaultInit(), BrowserFetch(), MsalBehavior(...))
+ * Standalone runtime bootstrap:
+ * - creates authenticated SPFI
+ * - auto-detects hub vs project context from live site URL
+ * - resolves Graph group membership for RBAC (with safe fallback)
  */
+import { InteractionRequiredAuthError } from '@azure/msal-browser';
+import type { AccountInfo, AuthenticationResult, IPublicClientApplication } from '@azure/msal-browser';
+import { BrowserFetch } from '@pnp/queryable/behaviors/browser-fetch';
 import { spfi, SPFI } from '@pnp/sp';
 import { DefaultHeaders, DefaultInit } from '@pnp/sp/behaviors/defaults';
-import { BrowserFetch } from '@pnp/queryable/behaviors/browser-fetch';
-import '@pnp/sp/webs';
-import '@pnp/sp/lists';
-import '@pnp/sp/items';
-import '@pnp/sp/folders';
-import '@pnp/sp/files';
-import '@pnp/sp/batching';
-import '@pnp/sp/site-users/web';
-import '@pnp/sp/hubsites';
-import type { AccountInfo, IPublicClientApplication } from '@azure/msal-browser';
+import type { ISiteContext } from '@hbc/sp-services';
+import { detectSiteContext } from '@hbc/sp-services';
 import { MsalBehavior } from './MsalBehavior';
+
+import '@pnp/sp/batching';
+import '@pnp/sp/files';
+import '@pnp/sp/folders';
+import '@pnp/sp/hubsites';
+import '@pnp/sp/items';
+import '@pnp/sp/lists';
+import '@pnp/sp/site-users/web';
+import '@pnp/sp/webs';
+
+export interface IStandaloneGraphMembership {
+  groupIds: Set<string>;
+  groupNames: Set<string>;
+}
+
+export interface IStandaloneAccountProfile {
+  aadObjectId: string;
+  email: string;
+  displayName: string;
+}
+
+export interface IStandaloneRuntimeContext {
+  sp: SPFI;
+  siteContext: ISiteContext;
+  graphMembership: IStandaloneGraphMembership;
+  accountProfile: IStandaloneAccountProfile;
+}
+
+const GRAPH_TRANSITIVE_GROUPS_URL = 'https://graph.microsoft.com/v1.0/me/transitiveMemberOf/microsoft.graph.group?$select=id,displayName&$top=999';
+const SP_SITE_OVERRIDE = process.env.SP_SITE_URL;
+
+function createSpfiInstance(
+  msalInstance: IPublicClientApplication,
+  account: AccountInfo,
+  siteUrl: string,
+  scope: string
+): SPFI {
+  return spfi(siteUrl).using(
+    DefaultHeaders(),
+    DefaultInit(),
+    BrowserFetch(),
+    MsalBehavior(msalInstance, account, scope)
+  );
+}
+
+async function acquireGraphToken(
+  msalInstance: IPublicClientApplication,
+  account: AccountInfo,
+  graphScopes: string[]
+): Promise<AuthenticationResult> {
+  try {
+    return await msalInstance.acquireTokenSilent({ account, scopes: graphScopes });
+  } catch (error) {
+    if (error instanceof InteractionRequiredAuthError) {
+      return msalInstance.acquireTokenPopup({ account, scopes: graphScopes });
+    }
+    throw error;
+  }
+}
+
+async function getCurrentUserGraphMembership(
+  msalInstance: IPublicClientApplication,
+  account: AccountInfo,
+  graphScopes: string[]
+): Promise<IStandaloneGraphMembership> {
+  const groupIds = new Set<string>();
+  const groupNames = new Set<string>();
+
+  if (graphScopes.length === 0) return { groupIds, groupNames };
+
+  try {
+    const token = await acquireGraphToken(msalInstance, account, graphScopes);
+    let nextUrl: string | undefined = GRAPH_TRANSITIVE_GROUPS_URL;
+
+    while (nextUrl) {
+      const response = await fetch(nextUrl, {
+        headers: {
+          Authorization: `Bearer ${token.accessToken}`,
+        },
+      });
+      if (!response.ok) {
+        throw new Error(`Graph membership request failed (${response.status})`);
+      }
+
+      const payload = (await response.json()) as {
+        value?: Array<{ id?: string; displayName?: string }>;
+        '@odata.nextLink'?: string;
+      };
+
+      for (const group of payload.value ?? []) {
+        if (group.id) groupIds.add(group.id.toLowerCase());
+        if (group.displayName) groupNames.add(group.displayName.trim().toLowerCase());
+      }
+
+      nextUrl = payload['@odata.nextLink'];
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[Standalone] Graph membership lookup failed; using email fallback only. ${message}`);
+  }
+
+  return { groupIds, groupNames };
+}
+
+function assertTenantOriginMatch(liveSiteUrl: string, hubSiteUrl: string): void {
+  const liveOrigin = new URL(liveSiteUrl).origin.toLowerCase();
+  const hubOrigin = new URL(hubSiteUrl).origin.toLowerCase();
+  if (liveOrigin !== hubOrigin) {
+    throw new Error(`[Standalone] Cross-tenant site detection blocked (${liveOrigin} !== ${hubOrigin}).`);
+  }
+}
+
+export async function createStandaloneRuntimeContext(
+  msalInstance: IPublicClientApplication,
+  account: AccountInfo,
+  hubSiteUrl: string,
+  sharePointScope: string,
+  graphScopes: string[],
+  siteUrlOverride?: string
+): Promise<IStandaloneRuntimeContext> {
+  const targetSiteUrl = siteUrlOverride || SP_SITE_OVERRIDE || hubSiteUrl;
+  const sp = createSpfiInstance(msalInstance, account, targetSiteUrl, sharePointScope);
+  const webInfo = await sp.web.select('Url')<{ Url: string }>();
+  assertTenantOriginMatch(webInfo.Url, hubSiteUrl);
+
+  const siteContext = detectSiteContext(webInfo.Url, hubSiteUrl);
+  const graphMembership = await getCurrentUserGraphMembership(msalInstance, account, graphScopes);
+  const accountProfile: IStandaloneAccountProfile = {
+    aadObjectId: account.localAccountId || account.homeAccountId,
+    email: account.username,
+    displayName: account.name || account.username,
+  };
+
+  return { sp, siteContext, graphMembership, accountProfile };
+}
 
 export function createStandaloneSpfi(
   msalInstance: IPublicClientApplication,
@@ -22,12 +154,7 @@ export function createStandaloneSpfi(
   hubSiteUrl: string,
   scope: string
 ): SPFI {
-  return spfi(hubSiteUrl).using(
-    DefaultHeaders(),
-    DefaultInit(),
-    BrowserFetch(),
-    MsalBehavior(msalInstance, account, scope)
-  );
+  return createSpfiInstance(msalInstance, account, hubSiteUrl, scope);
 }
 
 export type { SPFI };

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { App } from '@components/App';
 import { MockDataService, RoleName, StandaloneSharePointDataService } from '@hbc/sp-services';
 import type { IDataService } from '@hbc/sp-services';
+import type { ISiteContext } from '@hbc/sp-services';
 import { RoleSwitcher } from './RoleSwitcher';
 import { MSALAuthProvider } from './auth/MSALAuthProvider';
 import { MsalBoundary } from './auth/MsalBoundary';
@@ -27,6 +28,7 @@ const DevRoot: React.FC = () => {
   const [mode, setMode] = React.useState<DataServiceMode>(getInitialMode);
   const [standaloneService, setStandaloneService] = React.useState<IDataService | null>(null);
   const [standaloneUser, setStandaloneUser] = React.useState<{ displayName: string; email: string } | null>(null);
+  const [standaloneSiteContext, setStandaloneSiteContext] = React.useState<ISiteContext | null>(null);
   const [role, setRole] = React.useState<RoleValue>(getMockUserRole());
   const [authError, setAuthError] = React.useState<string | null>(null);
 
@@ -55,14 +57,20 @@ const DevRoot: React.FC = () => {
     localStorage.setItem(STORAGE_KEY, 'mock');
     setStandaloneService(null);
     setStandaloneUser(null);
+    setStandaloneSiteContext(null);
     setAuthError(null);
     setMode('mock');
   }, []);
 
   const handleStandaloneReady = React.useCallback(
-    (svc: IDataService, user: { displayName: string; email: string; loginName: string }) => {
+    (
+      svc: IDataService,
+      user: { displayName: string; email: string; loginName: string },
+      siteContext: ISiteContext
+    ) => {
       setStandaloneService(svc);
       setStandaloneUser(user);
+      setStandaloneSiteContext(siteContext);
     },
     []
   );
@@ -100,7 +108,7 @@ const DevRoot: React.FC = () => {
         <App
           key="standalone"
           dataService={standaloneService}
-          siteUrl={hubUrl}
+          siteUrl={standaloneSiteContext?.siteUrl ?? hubUrl}
           dataServiceMode="standalone"
         />
       </MsalBoundary>

--- a/dev/vite.standalone.config.ts
+++ b/dev/vite.standalone.config.ts
@@ -69,6 +69,7 @@ export default defineConfig(({ mode }) => {
       'process.env.AAD_CLIENT_ID': JSON.stringify(env.VITE_AAD_CLIENT_ID || ''),
       'process.env.AAD_TENANT_ID': JSON.stringify(env.VITE_AAD_TENANT_ID || ''),
       'process.env.SP_HUB_URL': JSON.stringify(env.VITE_SP_HUB_URL || ''),
+      'process.env.SP_SITE_URL': JSON.stringify(env.VITE_SP_SITE_URL || ''),
       'process.env.APPINSIGHTS_CONNECTION_STRING': JSON.stringify(env.VITE_APPINSIGHTS_CONNECTION_STRING || ''),
     },
     build: {

--- a/dev/webpack.config.js
+++ b/dev/webpack.config.js
@@ -84,6 +84,7 @@ module.exports = {
       'process.env.AAD_CLIENT_ID': JSON.stringify(process.env.VITE_AAD_CLIENT_ID || ''),
       'process.env.AAD_TENANT_ID': JSON.stringify(process.env.VITE_AAD_TENANT_ID || ''),
       'process.env.SP_HUB_URL': JSON.stringify(process.env.VITE_SP_HUB_URL || ''),
+      'process.env.SP_SITE_URL': JSON.stringify(process.env.VITE_SP_SITE_URL || ''),
       'process.env.APPINSIGHTS_CONNECTION_STRING': JSON.stringify(
         process.env.VITE_APPINSIGHTS_CONNECTION_STRING || ''
       ),

--- a/docs/standalone-mode.md
+++ b/docs/standalone-mode.md
@@ -1,0 +1,97 @@
+# Standalone Mode (Vite/Webpack Dev + MSAL + Graph RBAC)
+
+## Purpose and Scope
+Standalone mode allows running HBC Project Controls outside SPFx workbench while preserving the same `IDataService` contract, RBAC semantics, and permission-engine behavior used in SharePoint mode.
+
+Scope:
+- Standalone authentication bootstrap (`dev/auth/*`)
+- Standalone `SharePointDataService` delegation (`StandaloneSharePointDataService`)
+- Graph-assisted role resolution for the 14-role matrix
+- Hub vs project site auto-detection
+
+Out of scope:
+- Replacing SharePoint list-level security controls
+- Interactive AAD login in CI
+
+## Three-Mode Compatibility Matrix
+
+| Mode | Entry point | Auth | Data service | Notes |
+|---|---|---|---|---|
+| `mock` | `dev/index.tsx` | none | `MockDataService` | default local mode |
+| `standalone` | `dev/index.tsx` | MSAL browser | `StandaloneSharePointDataService` | Graph RBAC + project/hub detection |
+| `sharepoint` | `src/webparts/...WebPart.ts` | SPFx implicit | `SharePointDataService` | production SPFx packaging path |
+
+## Runtime Flow (Standalone Auth + Graph RBAC)
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant MSAL
+  participant SP as SharePoint REST
+  participant Graph
+  participant Svc as StandaloneSharePointDataService
+
+  User->>MSAL: Sign in (popup)
+  MSAL-->>Svc: Account + SP token scope
+  Svc->>SP: Resolve current web Url
+  SP-->>Svc: site Url
+  Svc->>Svc: detectSiteContext(hub vs project)
+  Svc->>Graph: /me/transitiveMemberOf (groups)
+  Graph-->>Svc: group ids + group names
+  Svc->>SP: App_Roles + permission templates + mappings
+  Svc-->>User: CurrentUser + resolved permissions
+```
+
+## Required Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `VITE_DATA_SERVICE_MODE` | yes | `mock` or `standalone` |
+| `VITE_AAD_CLIENT_ID` | standalone | Azure AD app client ID |
+| `VITE_AAD_TENANT_ID` | standalone | Tenant ID |
+| `VITE_SP_HUB_URL` | standalone | Hub site URL |
+| `VITE_APPINSIGHTS_CONNECTION_STRING` | optional | App Insights telemetry |
+| `VITE_SP_SITE_URL` | optional | Force standalone target site URL (defaults to hub) |
+
+## Graph Permissions
+Minimum for standalone RBAC validation:
+- `User.Read`
+- `Group.Read.All`
+
+Additional permissions may exist for other features (calendar, mail, chat), but RBAC group resolution depends on `Group.Read.All` consent.
+
+## Verification Commands
+Run in this order for standalone changes:
+
+1. `npm run validate:standalone-env`
+2. `npm run verify:standalone`
+3. `npm run test --workspace=packages/hbc-sp-services -- StandaloneRbacResolver`
+4. `npm run test:e2e -- playwright/mode-switch.spec.ts playwright/offline-mode.spec.ts playwright/standalone-auth.spec.ts`
+5. `npm run build:app` (SPFx regression guard)
+
+## Troubleshooting
+
+### Popup blocked or cancelled
+- Symptom: login button returns immediate auth error.
+- Action: allow popups for localhost and retry.
+
+### Missing Graph consent
+- Symptom: standalone loads but group-based role matching is incomplete.
+- Behavior: app falls back to email-based role matching from `App_Roles.UserOrGroup`.
+- Action: grant admin consent for `Group.Read.All`.
+
+### Role mismatch
+- Check `App_Roles` entries for:
+  - group name exact match,
+  - user email fallback,
+  - active flag.
+- Verify security-group mapping table has active `defaultTemplateId` for expected role group.
+
+### Offline behavior
+- Standalone keeps shell/UI responsive while network drops.
+- Offline toast indicates live-data features may be unavailable.
+
+## Security Boundaries and Audit Notes
+- Browser RBAC is a UX and workflow guard; SharePoint permissions remain the true data boundary.
+- Standalone blocks cross-tenant site-origin mismatch relative to configured hub URL.
+- Graph group fetch failures fail soft and preserve deterministic fallback behavior.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
+    "test:e2e:standalone-smoke": "playwright test playwright/mode-switch.spec.ts playwright/offline-mode.spec.ts playwright/standalone-auth.spec.ts",
     "test:a11y": "playwright test playwright/accessibility.spec.ts",
     "test:storybook": "test-storybook",
     "postinstall": "npm run build:lib",

--- a/packages/hbc-sp-services/src/services/__tests__/StandaloneRbacResolver.test.ts
+++ b/packages/hbc-sp-services/src/services/__tests__/StandaloneRbacResolver.test.ts
@@ -1,0 +1,135 @@
+import { RoleName, PermissionLevel } from '../../models/enums';
+import type { IRole } from '../../models/IRole';
+import type { IPermissionTemplate, IProjectTeamAssignment, ISecurityGroupMapping } from '../../models/IPermissionTemplate';
+import {
+  buildStandaloneCurrentUser,
+  resolveStandalonePermissions,
+  resolveStandaloneRoles,
+  type IStandaloneGraphMembership,
+} from '../standalone/resolveStandaloneRoles';
+
+function createRole(title: RoleName, principals: string[]): IRole {
+  return {
+    id: Math.floor(Math.random() * 10000),
+    Title: title,
+    UserOrGroup: principals,
+    UserOrGroupIds: [],
+    Permissions: [],
+    IsActive: true,
+  };
+}
+
+function createTemplate(id: number, name: string, toolKey: string): IPermissionTemplate {
+  return {
+    id,
+    name,
+    description: name,
+    isGlobal: false,
+    globalAccess: false,
+    identityType: 'Internal',
+    toolAccess: [{ toolKey, level: PermissionLevel.STANDARD, granularFlags: [] }],
+    isDefault: false,
+    isActive: true,
+    version: 1,
+    createdBy: 'test',
+    createdDate: '2026-01-01T00:00:00.000Z',
+    lastModifiedBy: 'test',
+    lastModifiedDate: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('Standalone RBAC resolver', () => {
+  it('resolves roles from Graph group names and email fallback', () => {
+    const roles: IRole[] = [
+      createRole(RoleName.ExecutiveLeadership, ['hbc - executive leadership']),
+      createRole(RoleName.BDRepresentative, ['bd.user@hbc.com']),
+    ];
+
+    const membership: IStandaloneGraphMembership = {
+      groupIds: new Set<string>(['a-group-id']),
+      groupNames: new Set<string>(['HBC - Executive Leadership']),
+    };
+
+    const resolved = resolveStandaloneRoles(roles, membership, 'bd.user@hbc.com');
+    expect(resolved).toEqual(expect.arrayContaining([RoleName.ExecutiveLeadership, RoleName.BDRepresentative]));
+  });
+
+  it('builds current user permissions from resolved roles', () => {
+    const roles: IRole[] = [createRole(RoleName.Marketing, ['hbc - marketing'])];
+    const membership: IStandaloneGraphMembership = {
+      groupIds: new Set<string>(),
+      groupNames: new Set<string>(['hbc - marketing']),
+    };
+
+    const user = buildStandaloneCurrentUser(
+      { id: 1, displayName: 'Test User', email: 'test@hbc.com', loginName: 'i:0#.f|membership|test@hbc.com' },
+      roles,
+      membership
+    );
+
+    expect(user.roles).toEqual([RoleName.Marketing]);
+    expect(user.permissions.has('marketing:dashboard:view')).toBe(true);
+  });
+
+  it('resolves project override template and granular flags', async () => {
+    const securityMappings: ISecurityGroupMapping[] = [
+      { id: 1, securityGroupId: 'id-1', securityGroupName: 'HBC - Project Managers', defaultTemplateId: 4, isActive: true },
+      { id: 2, securityGroupId: 'id-2', securityGroupName: 'HBC - Read Only', defaultTemplateId: 8, isActive: true },
+    ];
+
+    const defaultTemplate = createTemplate(4, 'Default Ops', 'schedule');
+    const overrideTemplate = createTemplate(9, 'Override Ops', 'buyout_log');
+
+    const assignments: IProjectTeamAssignment[] = [
+      {
+        id: 1,
+        projectCode: '25-042-01',
+        userId: 'u1',
+        userDisplayName: 'User',
+        userEmail: 'pm@hbc.com',
+        assignedRole: RoleName.OperationsTeam,
+        templateOverrideId: 9,
+        granularFlagOverrides: [{ toolKey: 'buyout_log', flags: ['can_approve_compliance'] }],
+        assignedBy: 'admin@hbc.com',
+        assignedDate: '2026-01-01T00:00:00.000Z',
+        isActive: true,
+      },
+    ];
+
+    const dataService = {
+      getSecurityGroupMappings: jest.fn().mockResolvedValue(securityMappings),
+      getPermissionTemplate: jest.fn().mockImplementation(async (id: number) => (id === 9 ? overrideTemplate : defaultTemplate)),
+      getProjectTeamAssignments: jest.fn().mockResolvedValue(assignments),
+    };
+
+    const resolved = await resolveStandalonePermissions({
+      dataService,
+      userEmail: 'pm@hbc.com',
+      projectCode: '25-042-01',
+      roles: [RoleName.OperationsTeam],
+    });
+
+    expect(resolved.source).toBe('ProjectOverride');
+    expect(resolved.templateId).toBe(9);
+    expect(resolved.granularFlags.buyout_log).toContain('can_approve_compliance');
+  });
+
+  it('falls back to unknown template when mapping cannot resolve', async () => {
+    const dataService = {
+      getSecurityGroupMappings: jest.fn().mockResolvedValue([]),
+      getPermissionTemplate: jest.fn().mockResolvedValue(null),
+      getProjectTeamAssignments: jest.fn().mockResolvedValue([]),
+    };
+
+    const resolved = await resolveStandalonePermissions({
+      dataService,
+      userEmail: 'readonly@hbc.com',
+      projectCode: null,
+      roles: [RoleName.RiskManagement],
+    });
+
+    expect(resolved.templateId).toBe(0);
+    expect(resolved.permissions.size).toBe(0);
+    expect(resolved.templateName).toBe('Unknown');
+  });
+});

--- a/packages/hbc-sp-services/src/services/index.ts
+++ b/packages/hbc-sp-services/src/services/index.ts
@@ -30,4 +30,5 @@ export { TemplateSyncService } from './TemplateSyncService';
 export type { IDiffResult } from './TemplateSyncService';
 export { StandaloneSharePointDataService } from './StandaloneSharePointDataService';
 export { createDelegatingService } from './createDelegatingService';
-export type { IBinaryAttachment } from './StandaloneSharePointDataService';
+export type { IBinaryAttachment, IStandaloneRbacContext } from './StandaloneSharePointDataService';
+export type { IStandaloneGraphMembership, IStandaloneUserIdentity } from './standalone/resolveStandaloneRoles';

--- a/packages/hbc-sp-services/src/services/standalone/resolveStandaloneRoles.ts
+++ b/packages/hbc-sp-services/src/services/standalone/resolveStandaloneRoles.ts
@@ -1,0 +1,227 @@
+import { RoleName, PermissionLevel } from '../../models/enums';
+import type { ICurrentUser, IRole } from '../../models/IRole';
+import type {
+  IProjectTeamAssignment,
+  IResolvedPermissions,
+  ISecurityGroupMapping,
+  IToolAccess,
+  IPermissionTemplate,
+} from '../../models/IPermissionTemplate';
+import type { IDataService } from '../IDataService';
+import { ROLE_PERMISSIONS } from '../../utils/permissions';
+import { TOOL_DEFINITIONS, resolveToolPermissions } from '../../utils/toolPermissionMap';
+
+export interface IStandaloneGraphMembership {
+  groupIds: ReadonlySet<string>;
+  groupNames: ReadonlySet<string>;
+}
+
+export interface IStandaloneUserIdentity {
+  id: number;
+  displayName: string;
+  email: string;
+  loginName: string;
+}
+
+const ROLE_TO_SECURITY_GROUP: Record<RoleName, string> = {
+  [RoleName.ExecutiveLeadership]: 'HBC - Executive Leadership',
+  [RoleName.DepartmentDirector]: 'HBC - Project Executives',
+  [RoleName.OperationsTeam]: 'HBC - Project Managers',
+  [RoleName.PreconstructionTeam]: 'HBC - Estimating',
+  [RoleName.BDRepresentative]: 'HBC - Business Development',
+  [RoleName.EstimatingCoordinator]: 'HBC - Estimating',
+  [RoleName.AccountingManager]: 'HBC - Accounting',
+  [RoleName.Legal]: 'HBC - Read Only',
+  [RoleName.RiskManagement]: 'HBC - Read Only',
+  [RoleName.Marketing]: 'HBC - Read Only',
+  [RoleName.QualityControl]: 'HBC - Read Only',
+  [RoleName.Safety]: 'HBC - Read Only',
+  [RoleName.IDS]: 'HBC - Read Only',
+  [RoleName.SharePointAdmin]: 'HBC - SharePoint Admins',
+};
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function toLowerSet(values: ReadonlySet<string>): Set<string> {
+  return new Set(Array.from(values, normalize));
+}
+
+function cloneToolAccess(toolAccess: IToolAccess[]): IToolAccess[] {
+  return toolAccess.map((tool) => ({
+    ...tool,
+    granularFlags: tool.granularFlags ? [...tool.granularFlags] : [],
+  }));
+}
+
+function mergeGranularFlagOverrides(toolAccess: IToolAccess[], assignment: IProjectTeamAssignment | null): void {
+  if (!assignment?.granularFlagOverrides) return;
+
+  for (const override of assignment.granularFlagOverrides) {
+    const target = toolAccess.find((ta) => ta.toolKey === override.toolKey);
+    if (!target) continue;
+    const merged = new Set<string>([...(target.granularFlags ?? []), ...override.flags]);
+    target.granularFlags = Array.from(merged);
+  }
+}
+
+function buildRolePermissions(roles: RoleName[]): Set<string> {
+  const permissions = new Set<string>();
+  for (const role of roles) {
+    const rolePermissions = ROLE_PERMISSIONS[role] ?? [];
+    rolePermissions.forEach((perm) => permissions.add(perm));
+  }
+  return permissions;
+}
+
+function isRoleMatch(
+  role: IRole,
+  graphGroupIds: Set<string>,
+  graphGroupNames: Set<string>,
+  email: string
+): boolean {
+  if (!role.IsActive) return false;
+
+  const principals = (role.UserOrGroup ?? []).map(normalize);
+  const principalIds = (role.UserOrGroupIds ?? []).map((id) => normalize(String(id)));
+
+  return principals.some((principal) => {
+    if (principal === email) return true;
+    if (graphGroupIds.has(principal)) return true;
+    if (graphGroupNames.has(principal)) return true;
+    return false;
+  }) || principalIds.some((id) => graphGroupIds.has(id));
+}
+
+export function resolveStandaloneRoles(
+  roleRows: IRole[],
+  graphMembership: IStandaloneGraphMembership,
+  email: string
+): RoleName[] {
+  const normalizedEmail = normalize(email);
+  const graphGroupIds = toLowerSet(graphMembership.groupIds);
+  const graphGroupNames = toLowerSet(graphMembership.groupNames);
+
+  const resolvedRoles = new Set<RoleName>();
+  for (const role of roleRows) {
+    if (isRoleMatch(role, graphGroupIds, graphGroupNames, normalizedEmail)) {
+      resolvedRoles.add(role.Title);
+    }
+  }
+
+  return Array.from(resolvedRoles);
+}
+
+export function buildStandaloneCurrentUser(
+  identity: IStandaloneUserIdentity,
+  roleRows: IRole[],
+  graphMembership: IStandaloneGraphMembership
+): ICurrentUser {
+  const roles = resolveStandaloneRoles(roleRows, graphMembership, identity.email);
+  return {
+    id: identity.id,
+    displayName: identity.displayName,
+    email: identity.email,
+    loginName: identity.loginName,
+    roles,
+    permissions: buildRolePermissions(roles),
+  };
+}
+
+function getDefaultTemplateId(roles: RoleName[], mappings: ISecurityGroupMapping[]): number {
+  for (const role of roles) {
+    const groupName = ROLE_TO_SECURITY_GROUP[role];
+    if (!groupName) continue;
+    const match = mappings.find((mapping) => mapping.isActive && mapping.securityGroupName === groupName);
+    if (match) return match.defaultTemplateId;
+  }
+
+  const readOnly = mappings.find((mapping) => mapping.isActive && mapping.securityGroupName === 'HBC - Read Only');
+  return readOnly?.defaultTemplateId ?? 0;
+}
+
+async function findProjectAssignment(
+  dataService: Pick<IDataService, 'getProjectTeamAssignments'>,
+  projectCode: string,
+  email: string
+): Promise<IProjectTeamAssignment | null> {
+  const assignments = await dataService.getProjectTeamAssignments(projectCode);
+  const normalizedEmail = normalize(email);
+  return assignments.find((assignment) => assignment.isActive && normalize(assignment.userEmail) === normalizedEmail) ?? null;
+}
+
+function buildResolvedPermissions(
+  userEmail: string,
+  projectCode: string | null,
+  source: IResolvedPermissions['source'],
+  template: IPermissionTemplate | null,
+  toolAccess: IToolAccess[]
+): IResolvedPermissions {
+  if (!template) {
+    return {
+      userId: userEmail,
+      projectCode,
+      templateId: 0,
+      templateName: 'Unknown',
+      source,
+      toolLevels: {},
+      granularFlags: {},
+      permissions: new Set<string>(),
+      globalAccess: false,
+    };
+  }
+
+  const permissionStrings = resolveToolPermissions(toolAccess, TOOL_DEFINITIONS);
+  const toolLevels: Record<string, PermissionLevel> = {};
+  const granularFlags: Record<string, string[]> = {};
+
+  for (const tool of toolAccess) {
+    toolLevels[tool.toolKey] = tool.level;
+    if (tool.granularFlags && tool.granularFlags.length > 0) {
+      granularFlags[tool.toolKey] = tool.granularFlags;
+    }
+  }
+
+  return {
+    userId: userEmail,
+    projectCode,
+    templateId: template.id,
+    templateName: template.name,
+    source,
+    toolLevels,
+    granularFlags,
+    permissions: new Set<string>(permissionStrings),
+    globalAccess: template.globalAccess,
+  };
+}
+
+export async function resolveStandalonePermissions(params: {
+  dataService: Pick<IDataService, 'getSecurityGroupMappings' | 'getPermissionTemplate' | 'getProjectTeamAssignments'>;
+  userEmail: string;
+  projectCode: string | null;
+  roles: RoleName[];
+}): Promise<IResolvedPermissions> {
+  const { dataService, userEmail, projectCode, roles } = params;
+  const mappings = await dataService.getSecurityGroupMappings();
+  const defaultTemplateId = getDefaultTemplateId(roles, mappings);
+
+  let source: IResolvedPermissions['source'] = 'SecurityGroupDefault';
+  let templateId = defaultTemplateId;
+  let projectAssignment: IProjectTeamAssignment | null = null;
+
+  if (projectCode) {
+    projectAssignment = await findProjectAssignment(dataService, projectCode, userEmail);
+    if (projectAssignment?.templateOverrideId) {
+      templateId = projectAssignment.templateOverrideId;
+      source = 'ProjectOverride';
+    }
+  }
+
+  const template = templateId ? await dataService.getPermissionTemplate(templateId) : null;
+  const toolAccess = template ? cloneToolAccess(template.toolAccess) : [];
+
+  mergeGranularFlagOverrides(toolAccess, projectAssignment);
+
+  return buildResolvedPermissions(userEmail, projectCode, source, template, toolAccess);
+}

--- a/playwright/mode-switch.spec.ts
+++ b/playwright/mode-switch.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Mode switching', () => {
+  test('mock -> standalone shell -> mock roundtrip', async ({ page }) => {
+    await page.goto('/#/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText(/mock mode/i)).toBeVisible({ timeout: 10_000 });
+
+    const loginButton = page.getByRole('button', { name: /login \(real data\)/i });
+    const hasLoginButton = await loginButton.isVisible().catch(() => false);
+    test.skip(!hasLoginButton, 'Standalone login button is hidden when AAD env is not configured.');
+
+    await loginButton.click();
+    await expect(page.getByText(/standalone mode/i)).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole('button', { name: /return to mock mode/i }).click();
+    await expect(page.getByText(/mock mode/i)).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/playwright/offline-mode.spec.ts
+++ b/playwright/offline-mode.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Offline monitor', () => {
+  test('shows offline warning and recovery toast', async ({ page, context }) => {
+    await page.goto('/#/');
+    await page.waitForLoadState('networkidle');
+
+    await context.setOffline(true);
+    await expect(page.getByRole('alert').filter({ hasText: /you are offline/i })).toBeVisible({ timeout: 10_000 });
+
+    await context.setOffline(false);
+    await expect(page.getByRole('alert').filter({ hasText: /back online/i })).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/playwright/standalone-auth.spec.ts
+++ b/playwright/standalone-auth.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Standalone auth shell', () => {
+  test('login shell is reachable from mock mode', async ({ page }) => {
+    await page.goto('/#/');
+    await page.waitForLoadState('networkidle');
+
+    const loginButton = page.getByRole('button', { name: /login \(real data\)/i });
+    const hasLoginButton = await loginButton.isVisible().catch(() => false);
+    test.skip(!hasLoginButton, 'Standalone login button is hidden when AAD env is not configured.');
+
+    await loginButton.click();
+    await expect(page.getByRole('heading', { name: /hbc project controls/i })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/standalone mode/i)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('button', { name: /sign in with microsoft/i })).toBeVisible({ timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
## Summary\n- add typed standalone runtime context with live site-context detection and Graph group membership lookup\n- enforce standalone getCurrentUser/resolveUserPermissions via Graph-aware RBAC helper with email fallback\n- add standalone operator docs and verification updates in PR template + CLAUDE\n- add standalone Playwright smoke specs for login shell, mode switching, and offline monitor\n\n## Verification\n- npm run build:lib\n- npm run test --workspace=packages/hbc-sp-services -- StandaloneRbacResolver\n- npm run test:e2e:standalone-smoke\n- npm run verify:standalone\n- npx tsc --noEmit\n- npm run lint\n- npm run test:ci\n- volta run --node 22.14.0 npm run build\n