### PR TITLE
Fix dev runtime process-is-not-defined in Template Site Sync

### DIFF
--- a/dev/vite.standalone.config.ts
+++ b/dev/vite.standalone.config.ts
@@ -70,6 +70,7 @@ export default defineConfig(({ mode }) => {
       'process.env.AAD_TENANT_ID': JSON.stringify(env.VITE_AAD_TENANT_ID || ''),
       'process.env.SP_HUB_URL': JSON.stringify(env.VITE_SP_HUB_URL || ''),
       'process.env.SP_SITE_URL': JSON.stringify(env.VITE_SP_SITE_URL || ''),
+      'process.env.GITOPS_FUNCTION_URL': JSON.stringify(env.VITE_GITOPS_FUNCTION_URL || ''),
       'process.env.APPINSIGHTS_CONNECTION_STRING': JSON.stringify(env.VITE_APPINSIGHTS_CONNECTION_STRING || ''),
     },
     build: {

--- a/dev/webpack.config.js
+++ b/dev/webpack.config.js
@@ -85,6 +85,7 @@ module.exports = {
       'process.env.AAD_TENANT_ID': JSON.stringify(process.env.VITE_AAD_TENANT_ID || ''),
       'process.env.SP_HUB_URL': JSON.stringify(process.env.VITE_SP_HUB_URL || ''),
       'process.env.SP_SITE_URL': JSON.stringify(process.env.VITE_SP_SITE_URL || ''),
+      'process.env.GITOPS_FUNCTION_URL': JSON.stringify(process.env.VITE_GITOPS_FUNCTION_URL || ''),
       'process.env.APPINSIGHTS_CONNECTION_STRING': JSON.stringify(
         process.env.VITE_APPINSIGHTS_CONNECTION_STRING || ''
       ),

--- a/src/webparts/hbcProjectControls/components/shared/TemplateSiteSyncPanel.tsx
+++ b/src/webparts/hbcProjectControls/components/shared/TemplateSiteSyncPanel.tsx
@@ -12,7 +12,10 @@ import { HBC_COLORS, SPACING } from '../../theme/tokens';
 
 // Azure Function URL for creating GitHub PRs.
 // If empty, the panel operates in mock/simulation mode.
-const GITOPS_FUNCTION_URL: string = (process.env as Record<string, string | undefined>).GITOPS_FUNCTION_URL ?? '';
+const GITOPS_FUNCTION_URL: string = (() => {
+  const maybeProcess = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
+  return maybeProcess?.env?.GITOPS_FUNCTION_URL ?? '';
+})();
 
 const useStyles = makeStyles({
   root: {


### PR DESCRIPTION
Summary
- Fix TemplateSiteSyncPanel env resolution so browser runtime does not dereference an undefined global process.
- Inject process.env.GITOPS_FUNCTION_URL in webpack dev DefinePlugin from VITE_GITOPS_FUNCTION_URL.
- Inject process.env.GITOPS_FUNCTION_URL in Vite standalone define config from VITE_GITOPS_FUNCTION_URL.

Validation
- npm run build:standalone